### PR TITLE
Fix that README.md has a broken link 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ On Fabric, it requires:
 - Cardinal Components
 - ClothConfig and ModMenu
 
-- [Read the documentation online here!](https://gamma-delta.github.io/HexMod/)
+- [Read the documentation online here!](https://fallingcolors.github.io/HexMod/)
 - [Discord link](https://discord.gg/4xxHGYteWk)
 
 ## The Branches


### PR DESCRIPTION
Following migration to fallingcolors org, README.md contained a broken link to the old gamma-delta online Hex Book. This PR changes the link to the new FallingColors online Hex Book.