### PR TITLE
Fix Quilt PAUCAL version spec

### DIFF
--- a/Fabric/src/main/resources/fabric.mod.json
+++ b/Fabric/src/main/resources/fabric.mod.json
@@ -55,7 +55,7 @@
     "cardinal-components-entity": "~5.2.1",
     "cardinal-components-item": "~5.2.1",
     "cardinal-components-block": "~5.2.1",
-    "paucal": "0.6.x",
+    "paucal": ">=0.6.0-pre <0.7.0",
     "cloth-config": "11.1.*",
     "patchouli": ">=1.20.1-80"
   },


### PR DESCRIPTION
Fixes an issue where the PAUCAL prerelease from Jenkins works fine on Fabric but is rejected on Quilt as not matching the version range.