### PR TITLE
fix weird dimensions sometimes having different great spells

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/iota/PatternIota.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/iota/PatternIota.java
@@ -69,7 +69,7 @@ public class PatternIota extends Iota {
     public @NotNull CastResult execute(CastingVM vm, ServerLevel world, SpellContinuation continuation) {
         @Nullable Component castedName = null;
         try {
-            var lookup = PatternRegistryManifest.matchPattern(this.getPattern(), world, false);
+            var lookup = PatternRegistryManifest.matchPattern(this.getPattern(), world.getServer().overworld(), false);
             vm.getEnv().precheckAction(lookup);
 
             Action action;

--- a/Common/src/main/java/at/petrak/hexcasting/common/command/PatternResLocArgument.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/command/PatternResLocArgument.java
@@ -47,7 +47,7 @@ public class PatternResLocArgument extends ResourceLocationArgument {
         CommandContext<CommandSourceStack> ctx, String argumentName) throws CommandSyntaxException {
         var targetId = ctx.getArgument(argumentName, ResourceLocation.class);
         var targetKey = ResourceKey.create(IXplatAbstractions.INSTANCE.getActionRegistry().key(), targetId);
-        var foundPat = PatternRegistryManifest.getCanonicalStrokesPerWorld(targetKey, ctx.getSource().getLevel());
+        var foundPat = PatternRegistryManifest.getCanonicalStrokesPerWorld(targetKey, ctx.getSource().getServer().overworld());
         if (foundPat == null) {
             throw ERROR_UNKNOWN_PATTERN.create(targetId);
         } else {


### PR DESCRIPTION
Apparently sometimes, depending on the mods running on a server, different dimensions can be generated from different seeds, resulting in them having different great spells.
In the current version, there are a couple lines where great spell finding methods are called with a seed that isn't guaranteed to be sourced from the overworld. My PR corrects this.