### PR TITLE
Added configured_feature entries for the edified trees (fixes #574)

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/common/lib/HexConfiguredFeatures.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/lib/HexConfiguredFeatures.java
@@ -1,29 +1,17 @@
 package at.petrak.hexcasting.common.lib;
 
-import net.minecraft.data.worldgen.BootstapContext;
-import net.minecraft.data.worldgen.features.FeatureUtils;
+import at.petrak.hexcasting.api.HexAPI;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
-import net.minecraft.world.level.levelgen.feature.Feature;
 
 public class HexConfiguredFeatures {
+    public static final ResourceKey<ConfiguredFeature<?, ?>> AMETHYST_EDIFIED_TREE = createKey("amethyst_edified_tree");
+    public static final ResourceKey<ConfiguredFeature<?, ?>> AVENTURINE_EDIFIED_TREE = createKey("aventurine_edified_tree");
+    public static final ResourceKey<ConfiguredFeature<?, ?>> CITRINE_EDIFIED_TREE = createKey("citrine_edified_tree");
 
-    public static void bootstrap(BootstapContext<ConfiguredFeature<?, ?>> context) {
-        context.register(AMETHYST_EDIFIED_TREE, new ConfiguredFeature<>(
-                Feature.TREE,
-                HexFeatureConfigs.AMETHYST_EDIFIED_TREE_CONFIG
-        ));
-        context.register(AVENTURINE_EDIFIED_TREE, new ConfiguredFeature<>(
-                Feature.TREE,
-                HexFeatureConfigs.AVENTURINE_EDIFIED_TREE_CONFIG
-        ));
-        context.register(CITRINE_EDIFIED_TREE, new ConfiguredFeature<>(
-                Feature.TREE,
-                HexFeatureConfigs.CITRINE_EDIFIED_TREE_CONFIG
-        ));
+    private static ResourceKey<ConfiguredFeature<?, ?>> createKey(String name) {
+        return ResourceKey.create(Registries.CONFIGURED_FEATURE, new ResourceLocation(HexAPI.MOD_ID, name));
     }
-
-    public static final ResourceKey<ConfiguredFeature<?, ?>> AMETHYST_EDIFIED_TREE = FeatureUtils.createKey("amethyst_edified_tree");
-    public static final ResourceKey<ConfiguredFeature<?, ?>> AVENTURINE_EDIFIED_TREE = FeatureUtils.createKey("aventurine_edified_tree");
-    public static final ResourceKey<ConfiguredFeature<?, ?>> CITRINE_EDIFIED_TREE = FeatureUtils.createKey("citrine_edified_tree");
 }

--- a/Common/src/main/java/at/petrak/hexcasting/common/lib/HexFeatureConfigs.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/lib/HexFeatureConfigs.java
@@ -1,5 +1,8 @@
 package at.petrak.hexcasting.common.lib;
 
+import at.petrak.hexcasting.api.HexAPI;
+import com.mojang.serialization.JsonOps;
+import net.minecraft.server.Bootstrap;
 import net.minecraft.util.random.SimpleWeightedRandomList;
 import net.minecraft.util.valueproviders.ConstantInt;
 import net.minecraft.world.level.block.Block;
@@ -14,6 +17,14 @@ import net.minecraft.world.level.levelgen.feature.trunkplacers.FancyTrunkPlacer;
 import java.util.OptionalInt;
 
 public class HexFeatureConfigs {
+    public static void dumpConfigs() {
+        // Used to generate the tree data json files
+        // Call this after the game is properly bootstrapped and copy the output logs to data/hexcasting/worldgen/configured_feature/${name}.json
+        // This should be done in DataGen, but I was unable to make that function. - dashkal16
+        HexAPI.LOGGER.info(TreeConfiguration.CODEC.encodeStart(JsonOps.INSTANCE, AMETHYST_EDIFIED_TREE_CONFIG));
+        HexAPI.LOGGER.info(TreeConfiguration.CODEC.encodeStart(JsonOps.INSTANCE, AVENTURINE_EDIFIED_TREE_CONFIG));
+        HexAPI.LOGGER.info(TreeConfiguration.CODEC.encodeStart(JsonOps.INSTANCE, CITRINE_EDIFIED_TREE_CONFIG));
+    }
 
     public static final TreeConfiguration AMETHYST_EDIFIED_TREE_CONFIG = akashicTree(HexBlocks.AMETHYST_EDIFIED_LEAVES, HexBlocks.EDIFIED_LOG_AMETHYST);
     public static final TreeConfiguration AVENTURINE_EDIFIED_TREE_CONFIG = akashicTree(HexBlocks.AVENTURINE_EDIFIED_LEAVES, HexBlocks.EDIFIED_LOG_AVENTURINE);

--- a/Common/src/main/resources/data/hexcasting/worldgen/configured_feature/amethyst_edified_tree.json
+++ b/Common/src/main/resources/data/hexcasting/worldgen/configured_feature/amethyst_edified_tree.json
@@ -1,0 +1,67 @@
+{
+  "type": "minecraft:tree",
+  "config": {
+    "decorators": [],
+    "ignore_vines": false,
+    "force_dirt": false,
+    "dirt_provider": {
+      "state": {
+        "Name": "minecraft:dirt"
+      },
+      "type": "minecraft:simple_state_provider"
+    },
+    "minimum_size": {
+      "limit": 0,
+      "lower_size": 0,
+      "upper_size": 0,
+      "min_clipped_height": 6,
+      "type": "minecraft:two_layers_feature_size"
+    },
+    "foliage_provider": {
+      "state": {
+        "Properties": {
+          "waterlogged": "false",
+          "persistent": "false",
+          "distance": "7"
+        },
+        "Name": "hexcasting:amethyst_edified_leaves"
+      },
+      "type": "minecraft:simple_state_provider"
+    },
+    "foliage_placer": {
+      "radius": 1,
+      "offset": 5,
+      "height": 5,
+      "type": "minecraft:fancy_foliage_placer"
+    },
+    "trunk_provider": {
+      "entries": [
+        {
+          "data": {
+            "Properties": {
+              "axis": "y"
+            },
+            "Name": "hexcasting:edified_log"
+          },
+          "weight": 8
+        },
+        {
+          "data": {
+            "Properties": {
+              "axis": "y"
+            },
+            "Name": "hexcasting:edified_log_amethyst"
+          },
+          "weight": 1
+        }
+      ],
+      "type": "minecraft:weighted_state_provider"
+    },
+    "trunk_placer": {
+      "base_height": 5,
+      "height_rand_a": 5,
+      "height_rand_b": 3,
+      "type": "minecraft:fancy_trunk_placer"
+    }
+  }
+}

--- a/Common/src/main/resources/data/hexcasting/worldgen/configured_feature/aventurine_edified_tree.json
+++ b/Common/src/main/resources/data/hexcasting/worldgen/configured_feature/aventurine_edified_tree.json
@@ -1,0 +1,67 @@
+{
+  "type": "minecraft:tree",
+  "config": {
+    "decorators": [],
+    "ignore_vines": false,
+    "force_dirt": false,
+    "dirt_provider": {
+      "state": {
+        "Name": "minecraft:dirt"
+      },
+      "type": "minecraft:simple_state_provider"
+    },
+    "minimum_size": {
+      "limit": 0,
+      "lower_size": 0,
+      "upper_size": 0,
+      "min_clipped_height": 6,
+      "type": "minecraft:two_layers_feature_size"
+    },
+    "foliage_provider": {
+      "state": {
+        "Properties": {
+          "waterlogged": "false",
+          "persistent": "false",
+          "distance": "7"
+        },
+        "Name": "hexcasting:citrine_edified_leaves"
+      },
+      "type": "minecraft:simple_state_provider"
+    },
+    "foliage_placer": {
+      "radius": 1,
+      "offset": 5,
+      "height": 5,
+      "type": "minecraft:fancy_foliage_placer"
+    },
+    "trunk_provider": {
+      "entries": [
+        {
+          "data": {
+            "Properties": {
+              "axis": "y"
+            },
+            "Name": "hexcasting:edified_log"
+          },
+          "weight": 8
+        },
+        {
+          "data": {
+            "Properties": {
+              "axis": "y"
+            },
+            "Name": "hexcasting:edified_log_citrine"
+          },
+          "weight": 1
+        }
+      ],
+      "type": "minecraft:weighted_state_provider"
+    },
+    "trunk_placer": {
+      "base_height": 5,
+      "height_rand_a": 5,
+      "height_rand_b": 3,
+      "type": "minecraft:fancy_trunk_placer"
+    }
+  }
+}

--- a/Common/src/main/resources/data/hexcasting/worldgen/configured_feature/citrine_edified_tree.json
+++ b/Common/src/main/resources/data/hexcasting/worldgen/configured_feature/citrine_edified_tree.json
@@ -1,0 +1,67 @@
+{
+  "type": "minecraft:tree",
+  "config": {
+    "decorators": [],
+    "ignore_vines": false,
+    "force_dirt": false,
+    "dirt_provider": {
+      "state": {
+        "Name": "minecraft:dirt"
+      },
+      "type": "minecraft:simple_state_provider"
+    },
+    "minimum_size": {
+      "limit": 0,
+      "lower_size": 0,
+      "upper_size": 0,
+      "min_clipped_height": 6,
+      "type": "minecraft:two_layers_feature_size"
+    },
+    "foliage_provider": {
+      "state": {
+        "Properties": {
+          "waterlogged": "false",
+          "persistent": "false",
+          "distance": "7"
+        },
+        "Name": "hexcasting:aventurine_edified_leaves"
+      },
+      "type": "minecraft:simple_state_provider"
+    },
+    "foliage_placer": {
+      "radius": 1,
+      "offset": 5,
+      "height": 5,
+      "type": "minecraft:fancy_foliage_placer"
+    },
+    "trunk_provider": {
+      "entries": [
+        {
+          "data": {
+            "Properties": {
+              "axis": "y"
+            },
+            "Name": "hexcasting:edified_log"
+          },
+          "weight": 8
+        },
+        {
+          "data": {
+            "Properties": {
+              "axis": "y"
+            },
+            "Name": "hexcasting:edified_log_aventurine"
+          },
+          "weight": 1
+        }
+      ],
+      "type": "minecraft:weighted_state_provider"
+    },
+    "trunk_placer": {
+      "base_height": 5,
+      "height_rand_a": 5,
+      "height_rand_b": 3,
+      "type": "minecraft:fancy_trunk_placer"
+    }
+  }
+}


### PR DESCRIPTION
Fixed edified trees by directly adding the tree configs to the common data pack.

Also fixed the resource keys being in the `minecraft` namespace as far as the code was concerned, making them impossible to find when things were registered.

I'm unhappy with this solution.  I feel like DataGen would be more appropriate, but I was unable to figure out how.