### PR TITLE
Make maxOpCount an Environment configurable value.

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/CastingEnvironment.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/CastingEnvironment.java
@@ -78,6 +78,10 @@ public abstract class CastingEnvironment {
         return this.world;
     }
 
+    public int maxOpCount() {
+        return HexConfig.server().maxOpCount();
+    }
+
     /**
      * Get the caster. Might be null!
      * <p>

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/iota/PatternIota.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/iota/PatternIota.java
@@ -106,7 +106,7 @@ public class PatternIota extends Iota {
                     continuation
             );
 
-            if (result.getNewImage().getOpsConsumed() > HexConfig.server().maxOpCount()) {
+            if (result.getNewImage().getOpsConsumed() > vm.getEnv().maxOpCount()) {
                 throw new MishapEvalTooMuch();
             }
 

--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/eval/OpThanos.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/eval/OpThanos.kt
@@ -11,7 +11,7 @@ import at.petrak.hexcasting.common.lib.hex.HexEvalSounds
 
 object OpThanos : Action {
     override fun operate(env: CastingEnvironment, image: CastingImage, continuation: SpellContinuation): OperationResult {
-        val opsLeft = HexConfig.server().maxOpCount() - image.opsConsumed
+        val opsLeft = env.maxOpCount() - image.opsConsumed
         val stack = image.stack.toMutableList()
         stack.add(DoubleIota(opsLeft.toDouble()))
 


### PR DESCRIPTION
I want to be able to make wisps have a lower maxOpCount than players since they'll be running their pattern list once a tick and thus the compute-restrictions should be stricter.