### PR TITLE
Add additional check for Forge to prevent crash with Origins.

### DIFF
--- a/Forge/src/main/java/at/petrak/hexcasting/forge/cap/adimpl/CapClientCastingStack.java
+++ b/Forge/src/main/java/at/petrak/hexcasting/forge/cap/adimpl/CapClientCastingStack.java
@@ -19,6 +19,6 @@ public record CapClientCastingStack(Player player, ClientCastingStack clientCast
     public static void tickClientPlayer(TickEvent.PlayerTickEvent evt) {
         if (evt.side == LogicalSide.CLIENT && !evt.player.isDeadOrDying())
             evt.player.getCapability(HexCapabilities.CLIENT_CASTING_STACK).resolve()
-                .get().get().tick();
+                .ifPresent(CastingStack -> CastingStack.get().tick());
     }
 }


### PR DESCRIPTION
A fix for #632's crash, if not a fix for why Origins is having issues with it - I've tested it a fair bit and have found no downsides so far, and the crash no longer occurs.