### PR TITLE
give the truenames their ambit back and add a config to remove it again

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/CastingEnvironment.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/CastingEnvironment.java
@@ -303,6 +303,7 @@ public abstract class CastingEnvironment {
      * Convenience function to throw if the entity is out of the caster's range or the world
      */
     public final void assertEntityInRange(Entity e) throws MishapEntityTooFarAway {
+        if (e instanceof ServerPlayer){return;}
         if (!this.isVecInWorld(e.position())) {
             throw new MishapEntityTooFarAway(e);
         }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/CastingEnvironment.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/CastingEnvironment.java
@@ -272,7 +272,7 @@ public abstract class CastingEnvironment {
     }
 
     public final boolean isEntityInRange(Entity e) {
-        return e instanceof Player || this.isVecInRange(e.position());
+        return (e instanceof Player && HexConfig.server().truenameHasAmbit()) || this.isVecInRange(e.position());
     }
 
     /**
@@ -303,7 +303,7 @@ public abstract class CastingEnvironment {
      * Convenience function to throw if the entity is out of the caster's range or the world
      */
     public final void assertEntityInRange(Entity e) throws MishapEntityTooFarAway {
-        if (e instanceof ServerPlayer){return;}
+        if (e instanceof ServerPlayer && HexConfig.server().truenameHasAmbit()){return;}
         if (!this.isVecInWorld(e.position())) {
             throw new MishapEntityTooFarAway(e);
         }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/CastingEnvironment.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/CastingEnvironment.java
@@ -272,7 +272,7 @@ public abstract class CastingEnvironment {
     }
 
     public final boolean isEntityInRange(Entity e) {
-        return (e instanceof Player && HexConfig.server().truenameHasAmbit()) || this.isVecInRange(e.position());
+        return (e instanceof Player && HexConfig.server().trueNameHasAmbit()) || this.isVecInRange(e.position());
     }
 
     /**
@@ -303,7 +303,9 @@ public abstract class CastingEnvironment {
      * Convenience function to throw if the entity is out of the caster's range or the world
      */
     public final void assertEntityInRange(Entity e) throws MishapEntityTooFarAway {
-        if (e instanceof ServerPlayer && HexConfig.server().truenameHasAmbit()){return;}
+        if (e instanceof ServerPlayer && HexConfig.server().trueNameHasAmbit()) {
+            return;
+        }
         if (!this.isVecInWorld(e.position())) {
             throw new MishapEntityTooFarAway(e);
         }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/CastingEnvironment.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/CastingEnvironment.java
@@ -272,7 +272,7 @@ public abstract class CastingEnvironment {
     }
 
     public final boolean isEntityInRange(Entity e) {
-        return (e instanceof Player && HexConfig.server().trueNameHasAmbit()) || this.isVecInRange(e.position());
+        return (e instanceof Player && HexConfig.server().trueNameHasAmbit()) || (this.isVecInWorld(e.position()) && this.isVecInRange(e.position()));
     }
 
     /**

--- a/Common/src/main/java/at/petrak/hexcasting/api/mod/HexConfig.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/mod/HexConfig.java
@@ -69,6 +69,8 @@ public class HexConfig {
         // fun fact, although dimension keys are a RegistryHolder, they aren't a registry, so i can't do tags
         boolean canTeleportInThisDimension(ResourceKey<Level> dimension);
 
+        boolean truenameHasAmbit();
+
         int DEFAULT_MAX_OP_COUNT = 1_000_000;
         int DEFAULT_MAX_SPELL_CIRCLE_LENGTH = 1024;
         int DEFAULT_OP_BREAK_HARVEST_LEVEL = 3;

--- a/Common/src/main/java/at/petrak/hexcasting/api/mod/HexConfig.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/mod/HexConfig.java
@@ -69,7 +69,7 @@ public class HexConfig {
         // fun fact, although dimension keys are a RegistryHolder, they aren't a registry, so i can't do tags
         boolean canTeleportInThisDimension(ResourceKey<Level> dimension);
 
-        boolean truenameHasAmbit();
+        boolean trueNameHasAmbit();
 
         int DEFAULT_MAX_OP_COUNT = 1_000_000;
         int DEFAULT_MAX_SPELL_CIRCLE_LENGTH = 1024;
@@ -78,6 +78,8 @@ public class HexConfig {
         boolean DEFAULT_VILLAGERS_DISLIKE_MIND_MURDER = true;
 
         List<String> DEFAULT_DIM_TP_DENYLIST = List.of("twilightforest:twilight_forest");
+
+        boolean DEFAULT_TRUE_NAME_HAS_AMBIT = true;
 
         default Tier opBreakHarvestLevel() {
             return switch (this.opBreakHarvestLevelBecauseForgeThoughtItWasAGoodIdeaToImplementHarvestTiersUsingAnHonestToGodTopoSort()) {

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexConfig.java
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexConfig.java
@@ -174,6 +174,9 @@ public class FabricHexConfig extends PartitioningSerializer.GlobalData {
         private List<String> circleActionDenyList = List.of();
         @ConfigEntry.Gui.Tooltip
         private boolean villagersOffendedByMindMurder = DEFAULT_VILLAGERS_DISLIKE_MIND_MURDER;
+        @ConfigEntry.Gui.Tooltip
+        private boolean doesTruenameHasAmbit = true;
+
 
         @ConfigEntry.Gui.Tooltip
         private List<String> tpDimDenylist = DEFAULT_DIM_TP_DENYLIST;
@@ -248,6 +251,11 @@ public class FabricHexConfig extends PartitioningSerializer.GlobalData {
         @Override
         public boolean canTeleportInThisDimension(ResourceKey<Level> dimension) {
             return noneMatch(tpDimDenylist, dimension.location());
+        }
+
+        @Override
+        public boolean truenameHasAmbit() {
+            return doesTruenameHasAmbit;
         }
 
         /**

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexConfig.java
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexConfig.java
@@ -175,7 +175,7 @@ public class FabricHexConfig extends PartitioningSerializer.GlobalData {
         @ConfigEntry.Gui.Tooltip
         private boolean villagersOffendedByMindMurder = DEFAULT_VILLAGERS_DISLIKE_MIND_MURDER;
         @ConfigEntry.Gui.Tooltip
-        private boolean doesTruenameHasAmbit = true;
+        private boolean doesTrueNameHaveAmbit = DEFAULT_TRUE_NAME_HAS_AMBIT;
 
 
         @ConfigEntry.Gui.Tooltip
@@ -254,8 +254,8 @@ public class FabricHexConfig extends PartitioningSerializer.GlobalData {
         }
 
         @Override
-        public boolean truenameHasAmbit() {
-            return doesTruenameHasAmbit;
+        public boolean trueNameHasAmbit() {
+            return doesTrueNameHaveAmbit;
         }
 
         /**

--- a/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexConfig.java
+++ b/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexConfig.java
@@ -134,6 +134,8 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
 
         private static ForgeConfigSpec.ConfigValue<List<? extends String>> tpDimDenyList;
 
+        private static ForgeConfigSpec.BooleanValue doesTruenameHaveAmbit;
+
         private static ForgeConfigSpec.ConfigValue<List<? extends String>> fewScrollTables;
         private static ForgeConfigSpec.ConfigValue<List<? extends String>> someScrollTables;
         private static ForgeConfigSpec.ConfigValue<List<? extends String>> manyScrollTables;
@@ -170,6 +172,10 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
 
             tpDimDenyList = builder.comment("Resource locations of dimensions you can't Blink or Greater Teleport in.")
                 .defineList("tpDimDenyList", DEFAULT_DIM_TP_DENYLIST, Server::isValidReslocArg);
+
+            doesTruenameHaveAmbit = builder.comment(
+                    "when false makes player reference iotas behave as normal entity reference iotas")
+                .define("doesTruenameHasAmbit",true);
         }
 
         @Override
@@ -205,6 +211,11 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
         @Override
         public boolean canTeleportInThisDimension(ResourceKey<Level> dimension) {
             return noneMatch(tpDimDenyList.get(), dimension.location());
+        }
+
+        @Override
+        public boolean truenameHasAmbit() {
+            return doesTruenameHaveAmbit.get();
         }
 
         private static boolean isValidReslocArg(Object o) {

--- a/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexConfig.java
+++ b/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexConfig.java
@@ -134,7 +134,7 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
 
         private static ForgeConfigSpec.ConfigValue<List<? extends String>> tpDimDenyList;
 
-        private static ForgeConfigSpec.BooleanValue doesTruenameHaveAmbit;
+        private static ForgeConfigSpec.BooleanValue doesTrueNameHaveAmbit;
 
         private static ForgeConfigSpec.ConfigValue<List<? extends String>> fewScrollTables;
         private static ForgeConfigSpec.ConfigValue<List<? extends String>> someScrollTables;
@@ -173,9 +173,9 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
             tpDimDenyList = builder.comment("Resource locations of dimensions you can't Blink or Greater Teleport in.")
                 .defineList("tpDimDenyList", DEFAULT_DIM_TP_DENYLIST, Server::isValidReslocArg);
 
-            doesTruenameHaveAmbit = builder.comment(
+            doesTrueNameHaveAmbit = builder.comment(
                     "when false makes player reference iotas behave as normal entity reference iotas")
-                .define("doesTruenameHasAmbit",true);
+                .define("doesTrueNameHaveAmbit", DEFAULT_TRUE_NAME_HAS_AMBIT);
         }
 
         @Override
@@ -214,8 +214,8 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
         }
 
         @Override
-        public boolean truenameHasAmbit() {
-            return doesTruenameHaveAmbit.get();
+        public boolean trueNameHasAmbit() {
+            return doesTrueNameHaveAmbit.get();
         }
 
         private static boolean isValidReslocArg(Object o) {


### PR DESCRIPTION
gives truenames ambit back as it was in 1.19
and makes env.isEntityInRange and env.assertEntityInRange behave the same
Identical to Walksinator's PR with style fixes, and make `isEntityInRange` include in world check.