### PR TITLE
Fix a couple of minor issues related to the casting VM

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingImage.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingImage.kt
@@ -67,6 +67,11 @@ data class CastingImage private constructor(
      */
     fun withOverriddenUsedOps(count: Long) = this.copy(opsConsumed = count)
 
+    /**
+     * Returns a copy of this with escape/paren-related fields cleared.
+     */
+    fun withResetEscape() = this.copy(parenCount = 0, parenthesized = listOf(), escapeNext = false)
+
     fun serializeToNbt() = NBTBuilder {
         TAG_STACK %= stack.serializeToNBT()
 

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingVM.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingVM.kt
@@ -188,7 +188,7 @@ class CastingVM(var image: CastingImage, val env: CastingEnvironment) {
                         val newParenCount = this.image.parenCount + if (last == null || last.escaped || last.iota !is PatternIota) 0 else when (last.iota.pattern) {
                             SpecialPatterns.INTROSPECTION -> -1
                             SpecialPatterns.RETROSPECTION -> 1
-                            else -> -1
+                            else -> 0
                         }
                         this.image.copy(parenthesized = newParens, parenCount = newParenCount) to if (last == null) ResolvedPatternType.ERRORED else ResolvedPatternType.UNDONE
                     }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/FrameForEach.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/FrameForEach.kt
@@ -73,7 +73,8 @@ data class FrameForEach(
         return CastResult(
             ListIota(code),
             newCont,
-            newImage.copy(stack = tStack),
+            // reset escapes so they don't carry over to other iterations or out of thoth
+            newImage.withResetEscape().copy(stack = tStack),
             listOf(),
             ResolvedPatternType.EVALUATED,
             HexEvalSounds.THOTH,


### PR DESCRIPTION
* Avoid changing the paren count when removing regular patterns with Evanition (fix #623)
  ![image](https://github.com/FallingColors/HexMod/assets/37044997/d0241304-d7cc-4cab-8a65-2fbd6a94a378)
* Fix escapes carrying over to subsequent Thoth iterations or out of the Thoth entirely
  ![image](https://github.com/FallingColors/HexMod/assets/37044997/e060e601-e2f8-498a-9a36-032dbacb2fd9)
  ![image](https://github.com/FallingColors/HexMod/assets/37044997/b5999c8d-4088-4acd-9bb9-9b889cb31f77)
