### PR TITLE
Fix circle break crash by terminating casting if the impetus ceases to exists at it's location (closes #661)

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/circles/CircleExecutionState.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/circles/CircleExecutionState.java
@@ -237,6 +237,9 @@ public class CircleExecutionState {
         var ctrl = executor.acceptControlFlow(this.currentImage, env, this.enteredFrom, this.currentPos,
             executorBlockState, world);
 
+        if (env.getImpetus() == null)
+            return false; //the impetus got removed during the cast and no longer exists in the world. stop casting
+
         if (ctrl instanceof ICircleComponent.ControlFlow.Stop) {
             // acceptControlFlow should have already posted the error
             halt = true;


### PR DESCRIPTION
added a guard statment that halts the circle's execution if the impetus is removed during a cast
this would close #661