### PR TITLE
Exclude loreInjections from auto config to have config work

### DIFF
--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexConfig.java
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexConfig.java
@@ -191,7 +191,7 @@ public class FabricHexConfig extends PartitioningSerializer.GlobalData {
         private transient Object2IntMap<ResourceLocation> scrollInjections;
 
         // TODO: hook this up to the config, change Jankery, test, also test scroll injects on fabric
-        @ConfigEntry.Gui.Tooltip
+        @ConfigEntry.Gui.Excluded
         private List<ResourceLocation> loreInjections = HexLootHandler.DEFAULT_LORE_INJECTS;
         @ConfigEntry.Gui.Tooltip
         private double loreChance = HexLootHandler.DEFAULT_LORE_CHANCE;


### PR DESCRIPTION
fixes #399. or should `loreInjections` be turned into a `List<String>` so it can be configured via mod menu?