### PR TITLE
Remove reference to nonexistent Combination Distillation

### DIFF
--- a/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
+++ b/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
@@ -1632,7 +1632,7 @@
         numlist: "Set operations are odd, in that some of them can accept two numbers or two lists, but not a combination thereof. Such arguments will be written as \"(num, num)|(list, list)\".$(br2)When numbers are used in those operations, they are being used as so-called binary \"bitsets\", lists of 1 and 0, true and false, \"on\" and \"off\".",
         
         "or.1": "Unifies two sets.",
-        "or.2": "As such:$(li)With two numbers at the top of the stack, combines them into a bitset containing every \"on\" bit in either bitset.$(li)With two lists, this creates a list of every element from the first list, plus every element from the second list that is not in the first list. This is similar to $(l:patterns/lists#hexcasting:add)$(action)Combination Distillation/$.",
+        "or.2": "As such:$(li)With two numbers at the top of the stack, combines them into a bitset containing every \"on\" bit in either bitset.$(li)With two lists, this creates a list of every element from the first list, plus every element from the second list that is not in the first list. This is somewhat similar to $(l:patterns/lists#hexcasting:add)$(action)Additive Distillation/$.",
         
         "and.1": "Takes the intersection of two sets.",
         "and.2": "As such:$(li)With two numbers at the top of the stack, combines them into a bitset containing every \"on\" bit present in $(italics)both/$ bitsets.$(li)With two lists, this creates a list of every element from the first list that is also in the second list.",


### PR DESCRIPTION
Fixes #753 by tweaking the description of Disjunction Distillation to mention Additive Distillation rather than Combination Distillation. Also slightly rewords the sentence to make it more clear that Disjunction Distillation and Additive Distillation are not quite the same thing.