### PR TITLE
Renamed Ignite Block to just Ignite

### DIFF
--- a/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
+++ b/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
@@ -728,7 +728,7 @@
         erase: "Erase Item",
         create_water: "Create Water",
         destroy_water: "Destroy Liquid",
-        ignite: "Ignite Block",
+        ignite: "Ignite",
         extinguish: "Extinguish Area",
         conjure_block: "Conjure Block",
         conjure_light: "Conjure Light",


### PR DESCRIPTION
I accidentally forgot this small change in the Ignite spell tweaks pull request.