### PR TITLE
Fix continuation-related exploits and bump* stack limit

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingImage.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingImage.kt
@@ -12,6 +12,7 @@ import net.minecraft.nbt.ListTag
 import net.minecraft.nbt.Tag
 import net.minecraft.server.level.ServerLevel
 import net.minecraft.world.entity.Entity
+import kotlin.math.max
 
 /**
  * The state of a casting VM, containing the stack and all
@@ -34,6 +35,27 @@ data class CastingImage private constructor(
             const val TAG_ESCAPED = "escaped"
         }
     }
+
+    private val size: Int
+    private val depth: Int
+
+    init {
+        var maxChildDepth = 0
+        var totalSize = 1
+        for (iota in stack) {
+            totalSize += iota.size()
+            maxChildDepth = max(maxChildDepth, iota.depth())
+        }
+        for (iota in parenthesized) {
+            totalSize += iota.iota.size()
+            maxChildDepth = max(maxChildDepth, iota.iota.depth())
+        }
+        depth = maxChildDepth
+        size = totalSize
+    }
+
+    fun size(): Int = size
+    fun depth(): Int = depth
 
     /**
      * Returns an empty list if it's too complicated.

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/ContinuationFrame.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/ContinuationFrame.kt
@@ -46,6 +46,7 @@ interface ContinuationFrame {
      * Return the number of iotas contained inside this frame, used for determining whether it is valid to serialise.
      */
     fun size(): Int
+    fun depth(): Int
 
     val type: Type<*>
 

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/ContinuationFrame.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/ContinuationFrame.kt
@@ -47,6 +47,7 @@ interface ContinuationFrame {
      */
     fun size(): Int
     fun depth(): Int
+    fun subIotas(): Iterable<Iota>?
 
     val type: Type<*>
 

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/FrameEvaluate.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/FrameEvaluate.kt
@@ -13,6 +13,7 @@ import at.petrak.hexcasting.common.lib.hex.HexIotaTypes
 import net.minecraft.nbt.CompoundTag
 import net.minecraft.nbt.Tag
 import net.minecraft.server.level.ServerLevel
+import kotlin.math.max
 
 /**
  * A list of patterns to be evaluated in sequence.
@@ -53,7 +54,22 @@ data class FrameEvaluate(val list: SpellList, val isMetacasting: Boolean) : Cont
         "isMetacasting" %= isMetacasting
     }
 
-    override fun size() = list.size()
+    private val size: Int
+    private val depth: Int
+
+    init {
+        var maxChildDepth = 0
+        var totalSize = 1
+        for (iota in list) {
+            totalSize += iota.size()
+            maxChildDepth = max(maxChildDepth, iota.depth())
+        }
+        depth = maxChildDepth
+        size = totalSize
+    }
+
+    override fun size() = size
+    override fun depth() = depth
 
     override val type: ContinuationFrame.Type<*> = TYPE
 

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/FrameEvaluate.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/FrameEvaluate.kt
@@ -70,6 +70,7 @@ data class FrameEvaluate(val list: SpellList, val isMetacasting: Boolean) : Cont
 
     override fun size() = size
     override fun depth() = depth
+    override fun subIotas(): Iterable<Iota> = list
 
     override val type: ContinuationFrame.Type<*> = TYPE
 

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/FrameFinishEval.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/FrameFinishEval.kt
@@ -36,6 +36,7 @@ object FrameFinishEval : ContinuationFrame {
     override fun serializeToNBT() = CompoundTag()
 
     override fun size() = 0
+    override fun depth() = 0
 
     @JvmField
     val TYPE: ContinuationFrame.Type<FrameFinishEval> = object : ContinuationFrame.Type<FrameFinishEval> {

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/FrameFinishEval.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/FrameFinishEval.kt
@@ -37,6 +37,7 @@ object FrameFinishEval : ContinuationFrame {
 
     override fun size() = 0
     override fun depth() = 0
+    override fun subIotas(): Iterable<Iota>? = null
 
     @JvmField
     val TYPE: ContinuationFrame.Type<FrameFinishEval> = object : ContinuationFrame.Type<FrameFinishEval> {

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/FrameForEach.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/FrameForEach.kt
@@ -14,6 +14,7 @@ import at.petrak.hexcasting.common.lib.hex.HexIotaTypes
 import net.minecraft.nbt.CompoundTag
 import net.minecraft.nbt.Tag
 import net.minecraft.server.level.ServerLevel
+import kotlin.math.max
 
 /**
  * A frame representing all the state for a Thoth evaluation.
@@ -89,7 +90,36 @@ data class FrameForEach(
         "accumulator" %= acc.serializeToNBT()
     }
 
-    override fun size() = data.size() + code.size() + acc.size + (baseStack?.size ?: 0)
+    private val size: Int
+    private val depth: Int
+
+    init {
+        var maxChildDepth = 0
+        var totalSize = 1
+        for (iota in data) {
+            totalSize += iota.size()
+            maxChildDepth = max(maxChildDepth, iota.depth())
+        }
+        for (iota in code) {
+            totalSize += iota.size()
+            maxChildDepth = max(maxChildDepth, iota.depth())
+        }
+        for (iota in acc) {
+            totalSize += iota.size()
+            maxChildDepth = max(maxChildDepth, iota.depth())
+        }
+        if (baseStack != null) {
+            for (iota in baseStack) {
+                totalSize += iota.size()
+                maxChildDepth = max(maxChildDepth, iota.depth())
+            }
+        }
+        depth = maxChildDepth
+        size = totalSize
+    }
+
+    override fun size() = size
+    override fun depth() = depth
 
     override val type: ContinuationFrame.Type<*> = TYPE
 

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/FrameForEach.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/FrameForEach.kt
@@ -120,6 +120,11 @@ data class FrameForEach(
 
     override fun size() = size
     override fun depth() = depth
+    override fun subIotas(): Iterable<Iota> =
+        if (baseStack != null)
+            listOf(data, code, acc, baseStack).flatten()
+        else
+            listOf(data, code, acc).flatten()
 
     override val type: ContinuationFrame.Type<*> = TYPE
 

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/SpellContinuation.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/SpellContinuation.kt
@@ -5,16 +5,26 @@ import at.petrak.hexcasting.api.utils.getList
 import net.minecraft.nbt.CompoundTag
 import net.minecraft.nbt.Tag
 import net.minecraft.server.level.ServerLevel
+import kotlin.math.max
 
 /**
  * A continuation during the execution of a spell.
  */
 sealed interface SpellContinuation {
-    object Done : SpellContinuation
+    object Done : SpellContinuation {
+        override fun size(): Int = 0
+        override fun depth(): Int = 0
+    }
 
-    data class NotDone(val frame: ContinuationFrame, val next: SpellContinuation) : SpellContinuation
+    data class NotDone(val frame: ContinuationFrame, val next: SpellContinuation) : SpellContinuation {
+        override fun size(): Int = frame.size() + next.size()
+        override fun depth(): Int = max(frame.depth(), next.depth())
+    }
 
     fun pushFrame(frame: ContinuationFrame): SpellContinuation = NotDone(frame, this)
+
+    fun size(): Int
+    fun depth(): Int
 
     fun serializeToNBT() = NBTBuilder {
         TAG_FRAME %= list(getNBTFrames())

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/iota/ContinuationIota.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/iota/ContinuationIota.java
@@ -13,6 +13,7 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -54,6 +55,11 @@ public class ContinuationIota extends Iota {
     @Override
     public boolean executable() {
         return true;
+    }
+
+    @Override
+    public @Nullable Iterable<Iota> subIotas() {
+        return this.getContinuation().subIotas();
     }
 
     @Override

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/iota/ContinuationIota.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/iota/ContinuationIota.java
@@ -58,15 +58,12 @@ public class ContinuationIota extends Iota {
 
     @Override
     public int size() {
-        var continuation = this.getContinuation();
-        var size = 0;
-        while (continuation instanceof SpellContinuation.NotDone notDone) {
-            size += 1;
-            size += notDone.component1().size();
-            continuation = notDone.component2();
-        }
+        return Math.min(this.getContinuation().size(), 1);
+    }
 
-        return Math.min(size, 1);
+    @Override
+    public int depth() {
+        return this.getContinuation().depth() + 1;
     }
 
     public static IotaType<ContinuationIota> TYPE = new IotaType<>() {

--- a/Common/src/main/java/at/petrak/hexcasting/common/lib/hex/HexIotaTypes.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/lib/hex/HexIotaTypes.java
@@ -23,7 +23,7 @@ public class HexIotaTypes {
         KEY_TYPE = HexAPI.MOD_ID + ":type",
         KEY_DATA = HexAPI.MOD_ID + ":data";
     public static final int MAX_SERIALIZATION_DEPTH = 256;
-    public static final int MAX_SERIALIZATION_TOTAL = 1024;
+    public static final int MAX_SERIALIZATION_TOTAL = 8192;
 
     public static void registerTypes(BiConsumer<IotaType<?>, ResourceLocation> r) {
         for (var e : TYPES.entrySet()) {


### PR DESCRIPTION
Bumps stack size limit to 8k, but includes extra iotas stored in current CastingImage in the tally(escaped iotas and continuations).
Also fixes iris truename smuggling by properly implementing subIotas.