### PR TITLE
Fix placeblock not pulling items from inventory when they are available.

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/spells/OpPlaceBlock.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/spells/OpPlaceBlock.kt
@@ -80,11 +80,11 @@ object OpPlaceBlock : SpellAction {
                         UseOnContext(env.world, caster as? ServerPlayer, env.otherHand, spoofedStack, blockHit)
                     val placeContext = BlockPlaceContext(itemUseCtx)
                     if (bstate.canBeReplaced(placeContext)) {
-                        if (env.withdrawItem({ it == placeeStack }, 1, false)) {
+                        if (env.withdrawItem({ ItemStack.isSameItemSameTags(it, placeeStack) }, 1, false)) {
                             val res = spoofedStack.useOn(placeContext)
 
                             if (res != InteractionResult.FAIL) {
-                                env.withdrawItem({ it == placeeStack }, 1, true)
+                                env.withdrawItem({ ItemStack.isSameItemSameTags(it, placeeStack) }, 1, true)
 
                                 env.world.playSound(
                                     caster as? ServerPlayer,


### PR DESCRIPTION
Fixes #671, whoops actually #783
The predicate now tests if objects in the inventory are the same item same tags instead of same object ref.