### PR TITLE
Remove The Media Cube category; move The Media Cube entry into Items and make it secret

### DIFF
--- a/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
+++ b/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
@@ -1128,16 +1128,12 @@
           It's probably just the ramblings of extinct traditionalists, though -- a pattern's a pattern.$(br2)\
           What could possibly go wrong?",
       },
-      creative_unlocker: {
-        "": "The Media Cube",
-        desc: "I have found a source of near limitless power, The Media Cube.",
-      }
     },
     // ^ categories
     
     entry: {
       media: "Media",
-      media_cube: "The Media Cube",
+      creative_unlocker: "The Media Cube",
       geodes: "Geodes",
       couldnt_cast: "A Frustration",
       start_to_see: "WHAT DID I SEE",

--- a/Common/src/main/resources/assets/hexcasting/patchouli_books/thehexbook/en_us/categories/creative_unlocker.json
+++ b/Common/src/main/resources/assets/hexcasting/patchouli_books/thehexbook/en_us/categories/creative_unlocker.json
@@ -1,7 +1,0 @@
-{
-  "name": "hexcasting.category.creative_unlocker",
-  "icon": "hexcasting:creative_unlocker",
-  "description": "hexcasting.category.creative_unlocker.desc",
-  "sortnum": 99,
-  "secret": true
-}

--- a/Common/src/main/resources/assets/hexcasting/patchouli_books/thehexbook/en_us/entries/items/creative_unlocker.json
+++ b/Common/src/main/resources/assets/hexcasting/patchouli_books/thehexbook/en_us/entries/items/creative_unlocker.json
@@ -1,10 +1,10 @@
 {
-  "name": "hexcasting.entry.media_cube",
+  "name": "hexcasting.entry.creative_unlocker",
   "icon": "hexcasting:creative_unlocker",
-  "category": "hexcasting:creative_unlocker",
-  "sortnum": 0,
-  "priority": true,
+  "category": "hexcasting:items",
+  "sortnum": 99,
   "advancement": "hexcasting:creative_unlocker",
+  "secret": true,
   "pages": [
     {
       "type": "patchouli:text",


### PR DESCRIPTION
This PR removes the entirely unnecessary dedicated category for the media cube, instead moving it into the Items category. It also sets the media cube entry to secret, so it doesn't show up as a locked entry in the book for players who have not picked up a media cube.