### PR TITLE
Stop fake players from bloodcasting

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/PlayerBasedCastEnv.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/PlayerBasedCastEnv.java
@@ -175,6 +175,10 @@ public abstract class PlayerBasedCastEnv extends CastingEnvironment {
     }
 
     protected boolean canOvercast() {
+        //bad deployer, no more infinite bloodcasting for you
+        if (this.caster.getClass() != ServerPlayer.class){
+            return false;
+        }
         var adv = this.world.getServer().getAdvancements().getAdvancement(modLoc("y_u_no_cast_angy"));
         var advs = this.caster.getAdvancements();
         return advs.getOrStartProgress(adv).isDone();


### PR DESCRIPTION
People on the discord have recently discovered that Create deployers in 1.20 can gain access to bloodcasting. Since their fakeplayer entities don't track health like real players do, this leads to the deployer essentially getting two free charged worth of media with every single cast. I do not think this exploit should be allowed to persist.