### PR TITLE
Make ConstMediaAction check for media cost later

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/castables/ConstMediaAction.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/castables/ConstMediaAction.kt
@@ -28,14 +28,15 @@ interface ConstMediaAction : Action {
     override fun operate(env: CastingEnvironment, image: CastingImage, continuation: SpellContinuation): OperationResult {
         val stack = image.stack.toMutableList()
 
-        if (env.extractMedia(this.mediaCost, true) > 0)
-            throw MishapNotEnoughMedia(this.mediaCost)
         if (this.argc > stack.size)
             throw MishapNotEnoughArgs(this.argc, stack.size)
         val args = stack.takeLast(this.argc)
         repeat(this.argc) { stack.removeLast() }
         val result = this.executeWithOpCount(args, env)
         stack.addAll(result.resultStack)
+
+        if (env.extractMedia(this.mediaCost, true) > 0)
+            throw MishapNotEnoughMedia(this.mediaCost)
 
         val sideEffects = mutableListOf<OperatorSideEffect>(OperatorSideEffect.ConsumeMedia(this.mediaCost))
 


### PR DESCRIPTION
Throwing MishapNotEnoughMedia early actually broke parity with SpellActions and pre-1.20 behaviour, since validation mishaps comes before MishapNotEnoughMedia. This moves simulated media extraction to after execution to restore parity. Note that this still doesn't let you raycast for free because a mishap thrown will void the new stack.