### PR TITLE
Update item rarities

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/common/lib/HexBlocks.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/lib/HexBlocks.java
@@ -163,15 +163,18 @@ public class HexBlocks {
     public static final BlockRightClickImpetus IMPETUS_RIGHTCLICK = blockItem("impetus/rightclick",
         new BlockRightClickImpetus(slateish()
             .pushReaction(PushReaction.BLOCK)
-            .lightLevel(bs -> bs.getValue(BlockAbstractImpetus.ENERGIZED) ? 15 : 0)));
+            .lightLevel(bs -> bs.getValue(BlockAbstractImpetus.ENERGIZED) ? 15 : 0)),
+        HexItems.props().rarity(Rarity.UNCOMMON));
     public static final BlockLookingImpetus IMPETUS_LOOK = blockItem("impetus/look",
         new BlockLookingImpetus(slateish()
             .pushReaction(PushReaction.BLOCK)
-            .lightLevel(bs -> bs.getValue(BlockAbstractImpetus.ENERGIZED) ? 15 : 0)));
+            .lightLevel(bs -> bs.getValue(BlockAbstractImpetus.ENERGIZED) ? 15 : 0)),
+        HexItems.props().rarity(Rarity.UNCOMMON));
     public static final BlockRedstoneImpetus IMPETUS_REDSTONE = blockItem("impetus/redstone",
         new BlockRedstoneImpetus(slateish()
             .pushReaction(PushReaction.BLOCK)
-            .lightLevel(bs -> bs.getValue(BlockAbstractImpetus.ENERGIZED) ? 15 : 0)));
+            .lightLevel(bs -> bs.getValue(BlockAbstractImpetus.ENERGIZED) ? 15 : 0)),
+        HexItems.props().rarity(Rarity.UNCOMMON));
 
 
     public static final BlockEmptyDirectrix EMPTY_DIRECTRIX = blockItem("directrix/empty",
@@ -179,10 +182,12 @@ public class HexBlocks {
             .pushReaction(PushReaction.BLOCK)));
     public static final BlockRedstoneDirectrix DIRECTRIX_REDSTONE = blockItem("directrix/redstone",
         new BlockRedstoneDirectrix(slateish()
-            .pushReaction(PushReaction.BLOCK)));
+            .pushReaction(PushReaction.BLOCK)),
+        HexItems.props().rarity(Rarity.UNCOMMON));
     public static final BlockBooleanDirectrix DIRECTRIX_BOOLEAN = blockItem("directrix/boolean",
         new BlockBooleanDirectrix(slateish()
-            .pushReaction(PushReaction.BLOCK)));
+            .pushReaction(PushReaction.BLOCK)),
+        HexItems.props().rarity(Rarity.UNCOMMON));
 
     public static final BlockAkashicRecord AKASHIC_RECORD = blockItem("akashic_record",
         new BlockAkashicRecord(akashicWoodyHard().lightLevel(bs -> 15)));
@@ -192,7 +197,10 @@ public class HexBlocks {
     public static final BlockAkashicLigature AKASHIC_LIGATURE = blockItem("akashic_connector",
         new BlockAkashicLigature(akashicWoodyHard().lightLevel(bs -> 4)));
 
-    public static final BlockQuenchedAllay QUENCHED_ALLAY = blockItem("quenched_allay", new BlockQuenchedAllay(quenched()));
+    public static final BlockQuenchedAllay QUENCHED_ALLAY = blockItem("quenched_allay", 
+        new BlockQuenchedAllay(quenched()), 
+        HexItems.props().rarity(Rarity.RARE)
+    );
 
     // Decoration?!
     public static final BlockQuenchedAllay QUENCHED_ALLAY_TILES = blockItem("quenched_allay_tiles", new BlockQuenchedAllay(quenched()));
@@ -233,8 +241,8 @@ public class HexBlocks {
             .mapColor(MapColor.COLOR_PURPLE)
             .sound(SoundType.AMETHYST)
             .strength(1f)
-            .lightLevel($ -> 15)),
-        HexItems.props().rarity(Rarity.RARE));
+            .lightLevel($ -> 15))
+        );
 
     public static final BlockAkashicLog EDIFIED_LOG = blockItem("edified_log",
         new BlockAkashicLog(edifiedWoody()));

--- a/Common/src/main/java/at/petrak/hexcasting/common/lib/HexItems.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/lib/HexItems.java
@@ -53,7 +53,7 @@ public class HexItems {
     public static final Item AMETHYST_DUST = make("amethyst_dust", new Item(props()));
     public static final Item CHARGED_AMETHYST = make("charged_amethyst", new Item(props()));
 
-    public static final Item QUENCHED_SHARD = make("quenched_allay_shard", new Item(props()));
+    public static final Item QUENCHED_SHARD = make("quenched_allay_shard", new Item(props().rarity(Rarity.UNCOMMON)));
 
     public static final ItemStaff STAFF_OAK = make("staff/oak", new ItemStaff(unstackable()));
     public static final ItemStaff STAFF_SPRUCE = make("staff/spruce", new ItemStaff(unstackable()));
@@ -67,9 +67,9 @@ public class HexItems {
     public static final ItemStaff STAFF_CHERRY = make("staff/cherry", new ItemStaff(unstackable()));
     public static final ItemStaff STAFF_BAMBOO = make("staff/bamboo", new ItemStaff(unstackable()));
     public static final ItemStaff STAFF_EDIFIED = make("staff/edified", new ItemStaff(unstackable()));
-    public static final ItemStaff STAFF_QUENCHED = make("staff/quenched", new ItemStaff(unstackable()));
+    public static final ItemStaff STAFF_QUENCHED = make("staff/quenched", new ItemStaff(unstackable().rarity(Rarity.UNCOMMON)));
     // mindsplice staffaratus
-    public static final ItemStaff STAFF_MINDSPLICE = make("staff/mindsplice", new ItemStaff(unstackable()));
+    public static final ItemStaff STAFF_MINDSPLICE = make("staff/mindsplice", new ItemStaff(unstackable().rarity(Rarity.UNCOMMON)));
 
     public static final ItemLens SCRYING_LENS = make("lens", new ItemLens(
         IXplatAbstractions.INSTANCE.addEquipSlotFabric(EquipmentSlot.HEAD)


### PR DESCRIPTION
Adds [rarity](https://minecraft.wiki/w/Rarity) to a few more items. Specifically:
- Filled impeti and directrices, along with the mindsplice staff, are now uncommon
- Quenched shards, along with the quenched staff, are now uncommon
- Quenched blocks are now rare

Also changes the rarity of the Amethyst Sconce back to common - why on earth was an easy-to-craft decorative block marked as rare?