### PR TITLE
Document bool directrix mishap

### DIFF
--- a/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
+++ b/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
@@ -1481,6 +1481,9 @@
         
         "no_record.title": "Lack Akashic Record",
         no_record: "Tried to access an $(l:greatwork/akashiclib)$(item)Akashic Record/$ at a location where there isn't one.$(br2)Causes purple sparks, and steals away some of my experience.",
+
+        "bad_shepherd.title": "Improper Shepherding",
+        bad_shepherd: "Tried to activate a $(l:greatwork/directrix)$(item)Shepherd Directrix/$ without a boolean on the top of the stack.$(br2)Causes red and white sparks, and forcibly ejects the Shepherd Directrix from the circle. This doesn't destroy it, thankfully, but I should make sure to go pick it up and replace it where it belongs.",
       },
       
       

--- a/Common/src/main/resources/assets/hexcasting/patchouli_books/thehexbook/en_us/entries/casting/mishaps2.json
+++ b/Common/src/main/resources/assets/hexcasting/patchouli_books/thehexbook/en_us/entries/casting/mishaps2.json
@@ -24,6 +24,11 @@
       "type": "patchouli:text",
       "title": "hexcasting.page.mishaps2.no_record.title",
       "text": "hexcasting.page.mishaps2.no_record"
+    },
+    {
+      "type": "patchouli:text",
+      "title": "hexcasting.page.mishaps2.bad_shepherd.title",
+      "text": "hexcasting.page.mishaps2.bad_shepherd"
     }
   ]
 }


### PR DESCRIPTION
Adds a page in the Enlightened Mishaps section describing what happens if you provide something that isn't a bool (or nothing at all) to a Shepherd Directrix. Internally these are two separate mishaps, but the effect is exactly the same so I think this single page covers both cases adequately.

![image](https://github.com/user-attachments/assets/1e9d3a8f-946d-4061-8881-f72de04847b3)
