### PR TITLE
Optimizes Spell Circles

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/circles/ICircleComponent.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/circles/ICircleComponent.java
@@ -11,10 +11,10 @@ import at.petrak.hexcasting.api.pigment.FrozenPigment;
 import at.petrak.hexcasting.common.lib.HexItems;
 import at.petrak.hexcasting.common.lib.HexSounds;
 import com.mojang.datafixers.util.Pair;
+import net.minecraft.ChatFormatting;
 import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.Mth;
@@ -147,10 +147,12 @@ public interface ICircleComponent {
      */
     default void fakeThrowMishap(BlockPos pos, BlockState bs, CastingImage image, CircleCastEnv env, Mishap mishap) {
         Mishap.Context errorCtx = new Mishap.Context(null,
-            bs.getBlock().getName().append(" (").append(Component.literal(pos.toShortString())).append(")"));
+            bs.getBlock().getName().withStyle(ChatFormatting.LIGHT_PURPLE));
         var sideEffect = new OperatorSideEffect.DoMishap(mishap, errorCtx);
         var vm = new CastingVM(image, env);
         sideEffect.performEffect(vm);
+        if (env.getImpetus() != null)
+            env.getImpetus().postMishap(mishap.errorMessageWithName(env,errorCtx));
     }
 
     abstract sealed class ControlFlow {

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/circle/MishapBoolDirectrixEmptyStack.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/circle/MishapBoolDirectrixEmptyStack.kt
@@ -4,6 +4,7 @@ import at.petrak.hexcasting.api.casting.eval.CastingEnvironment
 import at.petrak.hexcasting.api.casting.iota.Iota
 import at.petrak.hexcasting.api.casting.mishaps.Mishap
 import at.petrak.hexcasting.api.pigment.FrozenPigment
+import net.minecraft.ChatFormatting
 import net.minecraft.core.BlockPos
 import net.minecraft.network.chat.Component
 import net.minecraft.world.item.DyeColor
@@ -20,5 +21,6 @@ class MishapBoolDirectrixEmptyStack(
     }
 
     override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context): Component =
-        error("circle.bool_directrix.empty_stack", pos.toShortString())
+        error("circle.empty_stack", 1,
+            Component.literal("(").append(pos.toShortString()).append(")").withStyle(ChatFormatting.RED))
 }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/circle/MishapBoolDirectrixNotBool.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/circle/MishapBoolDirectrixNotBool.kt
@@ -4,6 +4,7 @@ import at.petrak.hexcasting.api.casting.eval.CastingEnvironment
 import at.petrak.hexcasting.api.casting.iota.Iota
 import at.petrak.hexcasting.api.casting.mishaps.Mishap
 import at.petrak.hexcasting.api.pigment.FrozenPigment
+import net.minecraft.ChatFormatting
 import net.minecraft.core.BlockPos
 import net.minecraft.network.chat.Component
 import net.minecraft.world.item.DyeColor
@@ -21,5 +22,7 @@ class MishapBoolDirectrixNotBool(
     }
 
     override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context): Component =
-        error("circle.bool_directrix_no_bool", pos.toShortString(), perpetrator.display())
+        error("circle.invalid_value", "boolean", 0,
+            Component.literal("(").append(pos.toShortString()).append(")").withStyle(ChatFormatting.RED),
+            perpetrator.display())
 }

--- a/Common/src/main/java/at/petrak/hexcasting/api/utils/ChunkScanning.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/utils/ChunkScanning.kt
@@ -1,0 +1,70 @@
+package at.petrak.hexcasting.api.utils
+
+import at.petrak.hexcasting.api.HexAPI
+import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap
+import net.minecraft.core.BlockPos
+import net.minecraft.server.level.ServerLevel
+import net.minecraft.world.level.ChunkPos
+import net.minecraft.world.level.block.entity.BlockEntity
+import net.minecraft.world.level.block.state.BlockState
+import net.minecraft.world.level.chunk.ChunkStatus
+import net.minecraft.world.level.chunk.ImposterProtoChunk
+
+/**
+ * This is a helper class to efficiently scan chunks in ways Minecraft did not intend for. This is for only reading chunks, not writing
+ *
+ * TODO: MAKE DOC THIS BETTER
+ */
+class ChunkScanning(var level: ServerLevel) {
+    var chunks: Long2ObjectLinkedOpenHashMap<ImposterProtoChunk> = Long2ObjectLinkedOpenHashMap()
+
+    /**
+     *  This attempts to cache a chunk to the local [chunks]
+     * @param ChunkPos the chunk to try to cache
+     * @return If the function could cache the chunk or not
+     */
+    fun cacheChunk(chunk: ChunkPos): Boolean {
+        val chunkLong = chunk.toLong()
+        // We have the chunk already, so we can skip it
+        if (chunks.contains(chunkLong)){
+            return true
+        }
+        val future = level.chunkSource.getChunkFuture(chunk.x,chunk.z, ChunkStatus.EMPTY,true).get()
+        if (future.left().isPresent){
+            chunks.put(chunkLong, future.left().get() as ImposterProtoChunk)
+            return true
+        }
+        HexAPI.LOGGER.warn("Failed to get chunk at {}!",chunk)
+        return false
+    }
+
+    fun cacheChunk(chunk: Long): Boolean{
+        return cacheChunk(ChunkPos(chunk))
+    }
+
+    fun getBlock(blockPos: BlockPos): BlockState? {
+        val chunkPos = ChunkPos(blockPos).toLong()
+        if (!cacheChunk(chunkPos)){
+            return null
+        }
+        return chunks.get(chunkPos).getBlockState(blockPos)
+    }
+
+    fun getBlockEntity(blockPos: BlockPos): BlockEntity? {
+        val chunkPos = ChunkPos(blockPos).toLong()
+        if (!cacheChunk(chunkPos)){
+            return null
+        }
+        return chunks.get(chunkPos).getBlockEntity(blockPos)
+    }
+
+    // maybe not required, but still not a bad idea to have a Clear method
+    fun clearCache(){
+        chunks.clear()
+    }
+
+    // TODO: Might not need this
+    fun containsChunk(chunk: ChunkPos): Boolean{
+        return chunks.contains(chunk.toLong())
+    }
+}

--- a/Common/src/main/java/at/petrak/hexcasting/common/blocks/circles/impetuses/BlockEntityRedstoneImpetus.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/blocks/circles/impetuses/BlockEntityRedstoneImpetus.java
@@ -88,7 +88,6 @@ public class BlockEntityRedstoneImpetus extends BlockEntityAbstractImpetus {
         if (e instanceof ServerPlayer player) {
             return player;
         } else {
-            HexAPI.LOGGER.error("Entity {} stored in a cleric impetus wasn't a player somehow", e);
             return null;
         }
     }

--- a/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
+++ b/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
@@ -1109,10 +1109,10 @@
         sapling: "a sapling",
         replaceable: "somewhere to place a block",
       },
-      
-      "circle.bool_directrix": {
-        no_bool: "the iota encountered at %s was %s, not a bool",
-        empty_stack: "the stack was empty at %s",
+
+      circle: {
+        empty_stack: "expected %s or more arguments but the stack was empty at %s",
+        invalid_value: "expected %s at index %s of the stack at %s, but got %s"
       },
     },
     // ^ mishap


### PR DESCRIPTION
In 1.20 Spell Circles can loop on their own slate, however this can cause massive NBT-Leaks due to the same positions stacking on the same positions. This PR just makes reachedPositions a HashSet/Set, and adds an extra Int Var of "reachedNumber", or how many slates it has come across (this is for the speed up of Spell Circles).