### PR TITLE
Fix Negation Purification arithmetic

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/common/lib/hex/HexActions.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/lib/hex/HexActions.java
@@ -170,6 +170,8 @@ public class HexActions {
         new OperationAction(HexPattern.fromAngles("wdw", HexDir.NORTH_EAST)));
     public static final ActionRegistryEntry OR = make("or",
         new OperationAction(HexPattern.fromAngles("waw", HexDir.SOUTH_EAST)));
+    public static final ActionRegistryEntry NOT = make("not",
+        new OperationAction(HexPattern.fromAngles("dw", HexDir.NORTH_WEST)));
     public static final ActionRegistryEntry XOR = make("xor",
         new OperationAction(HexPattern.fromAngles("dwa", HexDir.NORTH_WEST)));
     public static final ActionRegistryEntry GREATER = make("greater", new OperationAction(
@@ -188,8 +190,8 @@ public class HexActions {
         new ActionRegistryEntry(HexPattern.fromAngles("ad", HexDir.EAST), new OpEquality(false)));
     public static final ActionRegistryEntry NOT_EQUALS = make("not_equals",
         new ActionRegistryEntry(HexPattern.fromAngles("da", HexDir.EAST), new OpEquality(true)));
-    public static final ActionRegistryEntry NOT = make("not",
-        new ActionRegistryEntry(HexPattern.fromAngles("dw", HexDir.NORTH_WEST), OpBoolNot.INSTANCE));
+    // public static final ActionRegistryEntry NOT = make("not",
+    //     new ActionRegistryEntry(HexPattern.fromAngles("dw", HexDir.NORTH_WEST), OpBoolNot.INSTANCE));
     public static final ActionRegistryEntry BOOL_COERCE = make("bool_coerce",
         new ActionRegistryEntry(HexPattern.fromAngles("aw", HexDir.NORTH_EAST), OpCoerceToBool.INSTANCE));
     public static final ActionRegistryEntry IF = make("if",

--- a/Common/src/main/java/at/petrak/hexcasting/common/lib/hex/HexActions.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/lib/hex/HexActions.java
@@ -174,18 +174,14 @@ public class HexActions {
         new OperationAction(HexPattern.fromAngles("dw", HexDir.NORTH_WEST)));
     public static final ActionRegistryEntry XOR = make("xor",
         new OperationAction(HexPattern.fromAngles("dwa", HexDir.NORTH_WEST)));
-    public static final ActionRegistryEntry GREATER = make("greater", new OperationAction(
-        HexPattern.fromAngles("e", HexDir.SOUTH_EAST))
-    );
-    public static final ActionRegistryEntry LESS = make("less", new OperationAction(
-        HexPattern.fromAngles("q", HexDir.SOUTH_WEST))
-    );
-    public static final ActionRegistryEntry GREATER_EQ = make("greater_eq", new OperationAction(
-        HexPattern.fromAngles("ee", HexDir.SOUTH_EAST))
-    );
-    public static final ActionRegistryEntry LESS_EQ = make("less_eq", new OperationAction(
-        HexPattern.fromAngles("qq", HexDir.SOUTH_WEST))
-    );
+    public static final ActionRegistryEntry GREATER = make("greater", 
+        new OperationAction(HexPattern.fromAngles("e", HexDir.SOUTH_EAST)));
+    public static final ActionRegistryEntry LESS = make("less",
+        new OperationAction(HexPattern.fromAngles("q", HexDir.SOUTH_WEST)));
+    public static final ActionRegistryEntry GREATER_EQ = make("greater_eq", 
+        new OperationAction(HexPattern.fromAngles("ee", HexDir.SOUTH_EAST)));
+    public static final ActionRegistryEntry LESS_EQ = make("less_eq", 
+        new OperationAction(HexPattern.fromAngles("qq", HexDir.SOUTH_WEST)));
     public static final ActionRegistryEntry EQUALS = make("equals",
         new ActionRegistryEntry(HexPattern.fromAngles("ad", HexDir.EAST), new OpEquality(false)));
     public static final ActionRegistryEntry NOT_EQUALS = make("not_equals",


### PR DESCRIPTION
Fixes #868 by changing the HexActions entry for `dw` to use OperationAction rather than directly registering it to OpBoolNot