### PR TITLE
Update vectors.json to work with new psi domain

### DIFF
--- a/Common/src/main/resources/assets/hexcasting/patchouli_books/thehexbook/en_us/entries/casting/vectors.json
+++ b/Common/src/main/resources/assets/hexcasting/patchouli_books/thehexbook/en_us/entries/casting/vectors.json
@@ -20,7 +20,7 @@
       "type": "patchouli:link",
       "text": "hexcasting.page.vectors.3",
       "link_text": "hexcasting.page.vectors.3.link_text",
-      "url": "https://psi.vazkii.us/codex.php#vectorPrimer"
+      "url": "https://psi.vazkii.net/codex.php#vectorPrimer"
     }
   ]
 }


### PR DESCRIPTION
hey I just updated the domain for one of the buttons in the book because https://psi.vazkii.us/codex.php#vectorPrimer turned into https://psi.vazkii.net/codex.php#vectorPrimer