### PR TITLE
Fix broken lang on casting items with certain addons

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/spells/OpMakePackagedSpell.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/spells/OpMakePackagedSpell.kt
@@ -19,10 +19,11 @@ import net.minecraft.world.entity.item.ItemEntity
 import net.minecraft.world.item.ItemStack
 import net.minecraft.network.chat.Component
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 // TODO: How to handle in circles
-class OpMakePackagedSpell(val isValid: Predicate<ItemStack>, val expectedTypeDesc: Component, val cost: Long) : SpellAction {
-    constructor(itemType: ItemPackagedHex, cost: Long) : this({s -> s.`is`(itemType)}, itemType.description, cost) {}
+class OpMakePackagedSpell(val isValid: Predicate<ItemStack>, val expectedTypeDesc: Supplier<Component>, val cost: Long) : SpellAction {
+    constructor(itemType: ItemPackagedHex, cost: Long) : this({s -> s.`is`(itemType)}, itemType::getDescription, cost) {}
     
     override val argc = 2
     override fun execute(
@@ -36,11 +37,11 @@ class OpMakePackagedSpell(val isValid: Predicate<ItemStack>, val expectedTypeDes
             val hexHolder = IXplatAbstractions.INSTANCE.findHexHolder(it)
             isValid.test(it) && hexHolder != null && !hexHolder.hasHex()
         }
-            ?: throw MishapBadOffhandItem(ItemStack.EMPTY.copy(), expectedTypeDesc) // TODO: hack
+            ?: throw MishapBadOffhandItem(ItemStack.EMPTY.copy(), expectedTypeDesc.get()) // TODO: hack
 
         val hexHolder = IXplatAbstractions.INSTANCE.findHexHolder(handStack)
         if (!isValid.test(handStack)) {
-            throw MishapBadOffhandItem(handStack, expectedTypeDesc)
+            throw MishapBadOffhandItem(handStack, expectedTypeDesc.get())
         } else if (hexHolder == null || hexHolder.hasHex()) {
             throw MishapBadOffhandItem.of(handStack, "iota.write")
         }

--- a/Common/src/main/java/at/petrak/hexcasting/common/lib/hex/HexActions.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/lib/hex/HexActions.java
@@ -275,7 +275,7 @@ public class HexActions {
 
     public static final ActionRegistryEntry CRAFT$CYPHER = make("craft/cypher", new ActionRegistryEntry(
         HexPattern.fromAngles("waqqqqq", HexDir.EAST), 
-        new OpMakePackagedSpell(s -> (s.is(HexItems.CYPHER)||s.is(HexItems.ANCIENT_CYPHER)), HexItems.CYPHER.getDescription(), MediaConstants.CRYSTAL_UNIT)
+        new OpMakePackagedSpell(s -> (s.is(HexItems.CYPHER)||s.is(HexItems.ANCIENT_CYPHER)), HexItems.CYPHER::getDescription, MediaConstants.CRYSTAL_UNIT)
     ));
     public static final ActionRegistryEntry CRAFT$TRINKET = make("craft/trinket", new ActionRegistryEntry(
         HexPattern.fromAngles("wwaqqqqqeaqeaeqqqeaeq", HexDir.EAST), 


### PR DESCRIPTION
Fixes #917 by changing OpMakePackagedSpell to take `Supplier<Component>` for the item description rather than `Component`