### PR TITLE
Add null check to client config access in ListIota.display()

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/iota/ListIota.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/iota/ListIota.java
@@ -136,7 +136,7 @@ public class ListIota extends Iota {
                 if (i < list.size() - 1) {
                     var thisIotaNeedsComma = IotaType.getTypeFromTag(csub) != PatternIota.TYPE;
                     var nextIotaNeedsComma = IotaType.getTypeFromTag(HexUtils.downcast(list.get(i+1), CompoundTag.TYPE)) != PatternIota.TYPE;
-                    var alwaysShowCommas = HexConfig.client().alwaysShowListCommas();
+                    var alwaysShowCommas = HexConfig.client() != null && HexConfig.client().alwaysShowListCommas();
                     if (thisIotaNeedsComma || nextIotaNeedsComma || alwaysShowCommas)
                         out.append(", ");
                 }


### PR DESCRIPTION
Fixes #924 by defaulting the always-show-list-commas value to false if the client config doesn't exist (ie the display() call is being made server-side)