### PR TITLE
Change mishap parent class to `RuntimeException` to prevent game crashes

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingVM.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingVM.kt
@@ -74,7 +74,7 @@ class CastingVM(var image: CastingImage, val env: CastingEnvironment) {
             lastResolutionType = image2.resolutionType
             try {
                 performSideEffects(image2.sideEffects)
-            } catch (e: Exception) {
+            } catch (e: RuntimeException) {
                 e.printStackTrace()
                 performSideEffects(listOf(OperatorSideEffect.DoMishap(MishapInternalException(e), Mishap.Context(null, null))))
             }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingVM.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingVM.kt
@@ -74,7 +74,7 @@ class CastingVM(var image: CastingImage, val env: CastingEnvironment) {
             lastResolutionType = image2.resolutionType
             try {
                 performSideEffects(image2.sideEffects)
-            } catch (e: RuntimeException) {
+            } catch (e: Exception) {
                 e.printStackTrace()
                 performSideEffects(listOf(OperatorSideEffect.DoMishap(MishapInternalException(e), Mishap.Context(null, null))))
             }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/Mishap.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/Mishap.kt
@@ -18,8 +18,9 @@ import net.minecraft.world.entity.LivingEntity
 import net.minecraft.world.item.DyeColor
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.phys.Vec3
+import java.lang.RuntimeException
 
-abstract class Mishap : Throwable() {
+abstract class Mishap : RuntimeException() {
     /** Mishaps spray half-red, half-this-color. */
     abstract fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment
 


### PR DESCRIPTION
Fixes #891
Change mishap parent class to `RuntimeException`