### PR TITLE
Add ability to use handheld parent tag for rendering of cyphers/trinkets/artifacts

### DIFF
--- a/Common/src/generated/resources/assets/hexcasting/models/item/ancient_cypher_5.json
+++ b/Common/src/generated/resources/assets/hexcasting/models/item/ancient_cypher_5.json
@@ -1,5 +1,5 @@
 {
-  "parent": "minecraft:item/generated",
+  "parent": "minecraft:item/handheld_rod",
   "textures": {
     "layer0": "hexcasting:item/cad/5_ancient_cypher"
   }

--- a/Common/src/generated/resources/assets/hexcasting/models/item/ancient_cypher_5_filled.json
+++ b/Common/src/generated/resources/assets/hexcasting/models/item/ancient_cypher_5_filled.json
@@ -1,5 +1,5 @@
 {
-  "parent": "minecraft:item/generated",
+  "parent": "minecraft:item/handheld_rod",
   "textures": {
     "layer0": "hexcasting:item/cad/5_ancient_cypher",
     "layer1": "hexcasting:item/cad/5_ancient_cypher_overlay"

--- a/Common/src/generated/resources/assets/hexcasting/models/item/artifact_5.json
+++ b/Common/src/generated/resources/assets/hexcasting/models/item/artifact_5.json
@@ -1,5 +1,5 @@
 {
-  "parent": "minecraft:item/generated",
+  "parent": "minecraft:item/handheld_rod",
   "textures": {
     "layer0": "hexcasting:item/cad/5_artifact"
   }

--- a/Common/src/generated/resources/assets/hexcasting/models/item/artifact_5_filled.json
+++ b/Common/src/generated/resources/assets/hexcasting/models/item/artifact_5_filled.json
@@ -1,5 +1,5 @@
 {
-  "parent": "minecraft:item/generated",
+  "parent": "minecraft:item/handheld_rod",
   "textures": {
     "layer0": "hexcasting:item/cad/5_artifact",
     "layer1": "hexcasting:item/cad/5_artifact_overlay"

--- a/Common/src/generated/resources/assets/hexcasting/models/item/cypher_5.json
+++ b/Common/src/generated/resources/assets/hexcasting/models/item/cypher_5.json
@@ -1,5 +1,5 @@
 {
-  "parent": "minecraft:item/generated",
+  "parent": "minecraft:item/handheld_rod",
   "textures": {
     "layer0": "hexcasting:item/cad/5_cypher"
   }

--- a/Common/src/generated/resources/assets/hexcasting/models/item/cypher_5_filled.json
+++ b/Common/src/generated/resources/assets/hexcasting/models/item/cypher_5_filled.json
@@ -1,5 +1,5 @@
 {
-  "parent": "minecraft:item/generated",
+  "parent": "minecraft:item/handheld_rod",
   "textures": {
     "layer0": "hexcasting:item/cad/5_cypher",
     "layer1": "hexcasting:item/cad/5_cypher_overlay"

--- a/Common/src/generated/resources/assets/hexcasting/models/item/trinket_5.json
+++ b/Common/src/generated/resources/assets/hexcasting/models/item/trinket_5.json
@@ -1,5 +1,5 @@
 {
-  "parent": "minecraft:item/generated",
+  "parent": "minecraft:item/handheld_rod",
   "textures": {
     "layer0": "hexcasting:item/cad/5_trinket"
   }

--- a/Common/src/generated/resources/assets/hexcasting/models/item/trinket_5_filled.json
+++ b/Common/src/generated/resources/assets/hexcasting/models/item/trinket_5_filled.json
@@ -1,5 +1,5 @@
 {
-  "parent": "minecraft:item/generated",
+  "parent": "minecraft:item/handheld_rod",
   "textures": {
     "layer0": "hexcasting:item/cad/5_trinket",
     "layer1": "hexcasting:item/cad/5_trinket_overlay"

--- a/Forge/src/main/java/at/petrak/hexcasting/forge/datagen/xplat/HexItemModels.java
+++ b/Forge/src/main/java/at/petrak/hexcasting/forge/datagen/xplat/HexItemModels.java
@@ -26,6 +26,7 @@ import net.minecraftforge.client.model.generators.ModelFile;
 import net.minecraftforge.common.data.ExistingFileHelper;
 import net.minecraftforge.registries.ForgeRegistries;
 
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.BiFunction;
 
@@ -35,6 +36,8 @@ public class HexItemModels extends PaucalItemModelProvider {
     }
 
     private static final String[] PHIAL_SIZES = {"small", "medium", "large", "larger", "largest"};
+
+    private static final Integer[] PACKAGED_SPELL_HANDHELD_VARIANTS = {5};
 
     private static String getPath(Item item) {
         return Objects.requireNonNull(ForgeRegistries.ITEMS.getKey(item)).getPath();
@@ -276,11 +279,14 @@ public class HexItemModels extends PaucalItemModelProvider {
         var name = getPath(item);
         var builder = getBuilder(name);
         for (int i = 0; i < numVariants; i++) {
-            var plain = i == 0 ? singleTexture(name, new ResourceLocation("item/generated"),
+
+            var parent_tag = Arrays.asList(PACKAGED_SPELL_HANDHELD_VARIANTS).contains(i) ? "item/handheld_rod" : "item/generated";
+
+            var plain = i == 0 ? singleTexture(name, new ResourceLocation(parent_tag),
                     "layer0", modLoc("item/cad/" + i + "_" + stub))
-                    : withExistingParent(name + "_" + i, new ResourceLocation("item/generated"))
+                    : withExistingParent(name + "_" + i, new ResourceLocation(parent_tag))
                     .texture("layer0", modLoc("item/cad/" + i + "_" + stub));
-            var filled = withExistingParent(name + "_" + i + "_filled", new ResourceLocation("item/generated"))
+            var filled = withExistingParent(name + "_" + i + "_filled", new ResourceLocation(parent_tag))
                 .texture("layer0", modLoc("item/cad/" + i + "_" + stub))
                 .texture("layer1", modLoc("item/cad/" + i + "_" + stub + "_overlay"));
             builder.override().predicate(ItemFocus.VARIANT_PRED, i).predicate(ItemPackagedHex.HAS_PATTERNS_PRED, -0.01f)


### PR DESCRIPTION
Fixes #894 
add ability to use handheld parent tag for rendering of cyphers/trinkets/artifacts