### PR TITLE
[1.20.1] `CastingEnvironment#getCasterPosition`

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/CastingEnvironment.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/CastingEnvironment.java
@@ -129,6 +129,13 @@ public abstract class CastingEnvironment {
     public abstract LivingEntity getCastingEntity();
 
     /**
+     * Gets the caster's position. Useful for compatibility.
+     *
+     * @return the position of the caster
+     */
+    public abstract Vec3 getCastingPosition();
+
+    /**
      * Get an interface used to do mishaps
      */
     public abstract MishapEnvironment getMishapEnvironment();

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/CircleCastEnv.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/CircleCastEnv.java
@@ -48,6 +48,11 @@ public class CircleCastEnv extends CastingEnvironment {
         return this.execState.getCaster(this.world);
     }
 
+    @Override
+    public Vec3 getCastingPosition() {
+        return this.getImpetus() == null ? this.execState.impetusPos.getCenter() : this.getImpetus().getBlockPos().getCenter();
+    }
+
     public @Nullable BlockEntityAbstractImpetus getImpetus() {
         var entity = this.world.getBlockEntity(execState.impetusPos);
 

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/PlayerBasedCastEnv.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/PlayerBasedCastEnv.java
@@ -63,6 +63,11 @@ public abstract class PlayerBasedCastEnv extends CastingEnvironment {
     }
 
     @Override
+    public Vec3 getCastingPosition() {
+        return this.caster.position();
+    }
+
+    @Override
     public void postExecution(CastResult result) {
         super.postExecution(result);
 


### PR DESCRIPTION
I had a slight issue with implementing Hexcasting compatibilty for Ambit and Range testing in that i couldnt cleanly get the casting position from `CastingEnvironment`

This PR's purpose is to add such a method and its base implementations to Hexcasting

This *is* a breaking change for those addons that make custom `CastingEnvironment` implementations