### PR TITLE
Add keybinds for spellbook control and config to disable in-world scrolling

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/mod/HexConfig.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/mod/HexConfig.java
@@ -41,6 +41,8 @@ public class HexConfig {
     public interface ClientConfigAccess {
         boolean ctrlTogglesOffStrokeOrder();
 
+        boolean disableInworldScrolling();
+
         boolean invertSpellbookScrollDirection();
 
         boolean invertAbacusScrollDirection();
@@ -52,6 +54,7 @@ public class HexConfig {
         boolean alwaysShowListCommas();
 
         boolean DEFAULT_CTRL_TOGGLES_OFF_STROKE_ORDER = false;
+        boolean DEFAULT_DISABLE_INWORLD_SCROLLING = false;
         boolean DEFAULT_INVERT_SPELLBOOK_SCROLL = false;
         boolean DEFAULT_INVERT_ABACUS_SCROLL = false;
         double DEFAULT_GRID_SNAP_THRESHOLD = 0.5;

--- a/Common/src/main/java/at/petrak/hexcasting/client/Keybinds.java
+++ b/Common/src/main/java/at/petrak/hexcasting/client/Keybinds.java
@@ -1,0 +1,34 @@
+package at.petrak.hexcasting.client;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import net.minecraft.client.KeyMapping;
+
+import java.util.List;
+
+public class Keybinds {
+    public static final String CATEGORY = "category.hexcasting.binds";
+
+    public static KeyMapping spellbookPrev = new KeyMapping(
+            "key.hexcasting.spellbook_prev",
+            InputConstants.UNKNOWN.getValue(),
+            CATEGORY
+    );
+
+    public static KeyMapping spellbookNext = new KeyMapping(
+            "key.hexcasting.spellbook_next",
+            InputConstants.UNKNOWN.getValue(),
+            CATEGORY
+    );
+
+    public static List<KeyMapping> ALL_BINDS = List.of(spellbookPrev, spellbookNext);
+
+    public static void clientTickEnd() {
+        while (spellbookPrev.consumeClick()) {
+            ShiftScrollListener.onScroll(-1, false);
+        }
+
+        while (spellbookNext.consumeClick()) {
+            ShiftScrollListener.onScroll(1, false);
+        }
+    }
+}

--- a/Common/src/main/java/at/petrak/hexcasting/client/Keybinds.java
+++ b/Common/src/main/java/at/petrak/hexcasting/client/Keybinds.java
@@ -23,12 +23,15 @@ public class Keybinds {
     public static List<KeyMapping> ALL_BINDS = List.of(spellbookPrev, spellbookNext);
 
     public static void clientTickEnd() {
+        // because of how mouse scrolling works (scrolling upward moves the page down), a positive
+        // delta value makes the book flip backward while a negative one makes it flip forward
+
         while (spellbookPrev.consumeClick()) {
-            ShiftScrollListener.onScroll(-1, false);
+            ShiftScrollListener.onScroll(1, false);
         }
 
         while (spellbookNext.consumeClick()) {
-            ShiftScrollListener.onScroll(1, false);
+            ShiftScrollListener.onScroll(-1, false);
         }
     }
 }

--- a/Common/src/main/java/at/petrak/hexcasting/client/Keybinds.java
+++ b/Common/src/main/java/at/petrak/hexcasting/client/Keybinds.java
@@ -27,11 +27,11 @@ public class Keybinds {
         // delta value makes the book flip backward while a negative one makes it flip forward
 
         while (spellbookPrev.consumeClick()) {
-            ShiftScrollListener.onScroll(1, false);
+            ShiftScrollListener.onScroll(1, false, false);
         }
 
         while (spellbookNext.consumeClick()) {
-            ShiftScrollListener.onScroll(-1, false);
+            ShiftScrollListener.onScroll(-1, false, false);
         }
     }
 }

--- a/Common/src/main/java/at/petrak/hexcasting/client/ShiftScrollListener.java
+++ b/Common/src/main/java/at/petrak/hexcasting/client/ShiftScrollListener.java
@@ -17,6 +17,8 @@ public class ShiftScrollListener {
             return false;
         }
 
+        if (HexConfig.client().disableInworldScrolling()) return false;
+
         return onScroll(delta, true);
     }
 

--- a/Common/src/main/java/at/petrak/hexcasting/client/ShiftScrollListener.java
+++ b/Common/src/main/java/at/petrak/hexcasting/client/ShiftScrollListener.java
@@ -23,6 +23,10 @@ public class ShiftScrollListener {
     }
 
     public static boolean onScroll(double delta, boolean needsSneaking) {
+        return onScroll(delta, needsSneaking, true);
+    }
+
+    public static boolean onScroll(double delta, boolean needsSneaking, boolean allowInverting) {
         LocalPlayer player = Minecraft.getInstance().player;
         // not .isCrouching! that fails for players who are not on the ground
         // yes, this does work if you remap your sneak key
@@ -33,10 +37,10 @@ public class ShiftScrollListener {
             }
 
             if (IsScrollableItem(player.getMainHandItem().getItem())) {
-                mainHandDelta += delta;
+                mainHandDelta += delta * getScrollModifier(player.getMainHandItem().getItem(), allowInverting);
                 return true;
             } else if (IsScrollableItem(player.getOffhandItem().getItem())) {
-                offHandDelta += delta;
+                offHandDelta += delta * getScrollModifier(player.getOffhandItem().getItem(), allowInverting);
                 return true;
             }
         }
@@ -47,9 +51,8 @@ public class ShiftScrollListener {
     public static void clientTickEnd() {
         if (mainHandDelta != 0 || offHandDelta != 0) {
             IClientXplatAbstractions.INSTANCE.sendPacketToServer(
-                new MsgShiftScrollC2S(mainHandDelta, offHandDelta, Minecraft.getInstance().options.keySprint.isDown(),
-                    HexConfig.client().invertSpellbookScrollDirection(),
-                    HexConfig.client().invertAbacusScrollDirection()));
+                new MsgShiftScrollC2S(mainHandDelta, offHandDelta, Minecraft.getInstance().options.keySprint.isDown())
+            );
             mainHandDelta = 0;
             offHandDelta = 0;
         }
@@ -57,5 +60,17 @@ public class ShiftScrollListener {
 
     private static boolean IsScrollableItem(Item item) {
         return item == HexItems.SPELLBOOK || item == HexItems.ABACUS;
+    }
+
+    private static double getScrollModifier(Item item, boolean allowInverting) {
+        if (!allowInverting) return 1;
+
+        if (item == HexItems.SPELLBOOK) {
+            return HexConfig.client().invertSpellbookScrollDirection() ? -1 : 1;
+        } else if (item == HexItems.ABACUS) {
+            return HexConfig.client().invertAbacusScrollDirection() ? -1 : 1;
+        } else {
+            return 1;
+        }
     }
 }

--- a/Common/src/main/java/at/petrak/hexcasting/client/gui/GuiSpellcasting.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/client/gui/GuiSpellcasting.kt
@@ -12,6 +12,7 @@ import at.petrak.hexcasting.api.mod.HexConfig
 import at.petrak.hexcasting.api.mod.HexTags
 import at.petrak.hexcasting.api.utils.asTranslatedComponent
 import at.petrak.hexcasting.client.ClientTickCounter
+import at.petrak.hexcasting.client.Keybinds
 import at.petrak.hexcasting.client.ShiftScrollListener
 import at.petrak.hexcasting.client.ktxt.accumulatedScroll
 import at.petrak.hexcasting.client.render.*
@@ -311,6 +312,20 @@ class GuiSpellcasting constructor(
         ShiftScrollListener.onScroll(pDelta, false)
 
         return true
+    }
+
+    override fun keyPressed(key: Int, scancode: Int, modifiers: Int): Boolean {
+        if (super.keyPressed(key, scancode, modifiers)) return true
+
+        if (Keybinds.spellbookPrev.matches(key, scancode)) {
+            ShiftScrollListener.onScroll(-1.0, false)
+            return true
+        } else if (Keybinds.spellbookNext.matches(key, scancode)) {
+            ShiftScrollListener.onScroll(1.0, false)
+            return true
+        }
+
+        return false
     }
 
     override fun onClose() {

--- a/Common/src/main/java/at/petrak/hexcasting/client/gui/GuiSpellcasting.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/client/gui/GuiSpellcasting.kt
@@ -317,11 +317,13 @@ class GuiSpellcasting constructor(
     override fun keyPressed(key: Int, scancode: Int, modifiers: Int): Boolean {
         if (super.keyPressed(key, scancode, modifiers)) return true
 
+        // because of how mouse scrolling works (scrolling upward moves the page down), a positive
+        // delta value makes the book flip backward while a negative one makes it flip forward
         if (Keybinds.spellbookPrev.matches(key, scancode)) {
-            ShiftScrollListener.onScroll(-1.0, false)
+            ShiftScrollListener.onScroll(1.0, false)
             return true
         } else if (Keybinds.spellbookNext.matches(key, scancode)) {
-            ShiftScrollListener.onScroll(1.0, false)
+            ShiftScrollListener.onScroll(-1.0, false)
             return true
         }
 

--- a/Common/src/main/java/at/petrak/hexcasting/client/gui/GuiSpellcasting.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/client/gui/GuiSpellcasting.kt
@@ -320,10 +320,10 @@ class GuiSpellcasting constructor(
         // because of how mouse scrolling works (scrolling upward moves the page down), a positive
         // delta value makes the book flip backward while a negative one makes it flip forward
         if (Keybinds.spellbookPrev.matches(key, scancode)) {
-            ShiftScrollListener.onScroll(1.0, false)
+            ShiftScrollListener.onScroll(1.0, false, false)
             return true
         } else if (Keybinds.spellbookNext.matches(key, scancode)) {
-            ShiftScrollListener.onScroll(-1.0, false)
+            ShiftScrollListener.onScroll(-1.0, false, false)
             return true
         }
 

--- a/Common/src/main/java/at/petrak/hexcasting/common/msgs/MsgShiftScrollC2S.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/msgs/MsgShiftScrollC2S.java
@@ -24,8 +24,7 @@ import static at.petrak.hexcasting.api.HexAPI.modLoc;
  * Sent client->server when the client shift+scrolls with a shift-scrollable item
  * or scrolls in the spellcasting UI.
  */
-public record MsgShiftScrollC2S(double mainHandDelta, double offHandDelta, boolean isCtrl, boolean invertSpellbook,
-                                boolean invertAbacus) implements IMessage {
+public record MsgShiftScrollC2S(double mainHandDelta, double offHandDelta, boolean isCtrl) implements IMessage {
     public static final ResourceLocation ID = modLoc("scroll");
 
     @Override
@@ -38,17 +37,13 @@ public record MsgShiftScrollC2S(double mainHandDelta, double offHandDelta, boole
         var mainHandDelta = buf.readDouble();
         var offHandDelta = buf.readDouble();
         var isCtrl = buf.readBoolean();
-        var invertSpellbook = buf.readBoolean();
-        var invertAbacus = buf.readBoolean();
-        return new MsgShiftScrollC2S(mainHandDelta, offHandDelta, isCtrl, invertSpellbook, invertAbacus);
+        return new MsgShiftScrollC2S(mainHandDelta, offHandDelta, isCtrl);
     }
 
     public void serialize(FriendlyByteBuf buf) {
         buf.writeDouble(this.mainHandDelta);
         buf.writeDouble(this.offHandDelta);
         buf.writeBoolean(this.isCtrl);
-        buf.writeBoolean(this.invertSpellbook);
-        buf.writeBoolean(this.invertAbacus);
     }
 
     public void handle(MinecraftServer server, ServerPlayer sender) {
@@ -71,10 +66,6 @@ public record MsgShiftScrollC2S(double mainHandDelta, double offHandDelta, boole
     }
 
     private void spellbook(ServerPlayer sender, InteractionHand hand, ItemStack stack, double delta) {
-        if (invertSpellbook) {
-            delta = -delta;
-        }
-
         var newIdx = ItemSpellbook.rotatePageIdx(stack, delta < 0.0);
 
         var len = ItemSpellbook.highestPage(stack);
@@ -115,10 +106,6 @@ public record MsgShiftScrollC2S(double mainHandDelta, double offHandDelta, boole
     }
 
     private void abacus(ServerPlayer sender, InteractionHand hand, ItemStack stack, double delta) {
-        if (invertAbacus) {
-            delta = -delta;
-        }
-
         var increase = delta < 0;
         double num = NBTHelper.getDouble(stack, ItemAbacus.TAG_VALUE);
 

--- a/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
+++ b/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
@@ -265,6 +265,15 @@
   "gui.hexcasting": {
     spellcasting: "Hex Grid",
   },
+
+  "category.hexcasting": {
+    "binds": "Hex Casting",
+  },
+
+  "key.hexcasting": {
+    "spellbook_prev": "Previous Spellbook Page",
+    "spellbook_next": "Next Spellbook Page",
+  },
   
   "tag.hexcasting": {
     staves: "Hex Staves",

--- a/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
+++ b/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
@@ -344,13 +344,17 @@
           "": "Ctrl Toggles Off Stroke Order",
           "@Tooltip": "Whether the ctrl key will instead turn *off* the color gradient on patterns",
         },
+        disableInworldScrolling: {
+          "": "Disable In-World Scrolling",
+          "@Tooltip": "Disable scrolling input for spellbooks and abaci in the normal world, keeping keybinds and staff screen scrolling normal"
+        },
         invertSpellbookScrollDirection: {
           "": "Invert Spellbook Scroll Direction",
           "@Tooltip": "Whether scrolling up (as opposed to down) will increase the page index of the spellbook, and vice versa",
         },
         invertAbacusScrollDirection: {
           "": "Invert Abacus Scroll Direction",
-          "@Tooltip": "Whether scrolling up (as opposed to down) will increase the page index of the abacus, and vice versa",
+          "@Tooltip": "Whether scrolling up (as opposed to down) will increase the value of the abacus, and vice versa",
         },
         gridSnapThreshold: {
           "": "Grid Snap Threshold",

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexClientInitializer.kt
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexClientInitializer.kt
@@ -1,6 +1,7 @@
 package at.petrak.hexcasting.fabric
 
 import at.petrak.hexcasting.client.ClientTickCounter
+import at.petrak.hexcasting.client.Keybinds
 import at.petrak.hexcasting.client.RegisterClientStuff
 import at.petrak.hexcasting.client.ShiftScrollListener
 import at.petrak.hexcasting.client.gui.PatternTooltipComponent
@@ -13,6 +14,7 @@ import at.petrak.hexcasting.fabric.network.FabricPacketHandler
 import at.petrak.hexcasting.interop.HexInterop
 import net.fabricmc.api.ClientModInitializer
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper
 import net.fabricmc.fabric.api.client.model.ModelLoadingRegistry
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents
 import net.fabricmc.fabric.api.client.particle.v1.ParticleFactoryRegistry
@@ -37,6 +39,7 @@ object FabricHexClientInitializer : ClientModInitializer {
         WorldRenderEvents.START.register { ClientTickCounter.renderTickStart(it.tickDelta()) }
         ClientTickEvents.END_CLIENT_TICK.register {
             ClientTickCounter.clientTickEnd()
+            Keybinds.clientTickEnd()
             ShiftScrollListener.clientTickEnd()
         }
         TooltipComponentCallback.EVENT.register(PatternTooltipComponent::tryConvert)
@@ -45,6 +48,8 @@ object FabricHexClientInitializer : ClientModInitializer {
         }
 
         MouseScrollCallback.EVENT.register(ShiftScrollListener::onScrollInGameplay)
+
+        Keybinds.ALL_BINDS.forEach(KeyBindingHelper::registerKeyBinding)
 
         RegisterClientStuff.init()
         HexModelLayers.init { loc, defn -> EntityModelLayerRegistry.registerModelLayer(loc, defn::get) }

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexConfig.java
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexConfig.java
@@ -15,7 +15,6 @@ import me.shedaniel.autoconfig.serializer.GsonConfigSerializer;
 import me.shedaniel.autoconfig.serializer.PartitioningSerializer;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.util.RandomSource;
 import net.minecraft.util.Mth;
 import net.minecraft.world.level.Level;
 
@@ -129,9 +128,11 @@ public class FabricHexConfig extends PartitioningSerializer.GlobalData {
         @ConfigEntry.Gui.Tooltip
         private boolean ctrlTogglesOffStrokeOrder = DEFAULT_CTRL_TOGGLES_OFF_STROKE_ORDER;
         @ConfigEntry.Gui.Tooltip
+        private boolean disableInworldScrolling = DEFAULT_DISABLE_INWORLD_SCROLLING;
+        @ConfigEntry.Gui.Tooltip
         private boolean invertSpellbookScrollDirection = DEFAULT_INVERT_SPELLBOOK_SCROLL;
         @ConfigEntry.Gui.Tooltip
-        private boolean invertAbacusScrollDirection = DEFAULT_INVERT_SPELLBOOK_SCROLL;
+        private boolean invertAbacusScrollDirection = DEFAULT_INVERT_ABACUS_SCROLL;
         @ConfigEntry.Gui.Tooltip
         private double gridSnapThreshold = DEFAULT_GRID_SNAP_THRESHOLD;
         @ConfigEntry.Gui.Tooltip
@@ -147,6 +148,11 @@ public class FabricHexConfig extends PartitioningSerializer.GlobalData {
         @Override
         public boolean ctrlTogglesOffStrokeOrder() {
             return ctrlTogglesOffStrokeOrder;
+        }
+
+        @Override
+        public boolean disableInworldScrolling() {
+            return disableInworldScrolling;
         }
 
         @Override

--- a/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexClientInitializer.java
+++ b/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexClientInitializer.java
@@ -1,6 +1,7 @@
 package at.petrak.hexcasting.forge;
 
 import at.petrak.hexcasting.client.ClientTickCounter;
+import at.petrak.hexcasting.client.Keybinds;
 import at.petrak.hexcasting.client.RegisterClientStuff;
 import at.petrak.hexcasting.client.ShiftScrollListener;
 import at.petrak.hexcasting.client.gui.PatternTooltipComponent;
@@ -28,6 +29,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
 import java.io.IOException;
 import java.util.function.Function;
@@ -73,6 +75,7 @@ public class ForgeHexClientInitializer {
         evBus.addListener((TickEvent.ClientTickEvent e) -> {
             if (e.phase == TickEvent.Phase.END) {
                 ClientTickCounter.clientTickEnd();
+                Keybinds.clientTickEnd();
                 ShiftScrollListener.clientTickEnd();
             }
         });
@@ -135,5 +138,10 @@ public class ForgeHexClientInitializer {
 
             skin.addLayer(new AltioraLayer<>(skin, evt.getEntityModels()));
         });
+    }
+
+    @SubscribeEvent
+    public static void registerBinds(RegisterKeyMappingsEvent event) {
+        Keybinds.ALL_BINDS.forEach(event::register);
     }
 }

--- a/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexConfig.java
+++ b/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexConfig.java
@@ -5,7 +5,6 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.ForgeConfigSpec;
-import net.minecraft.util.RandomSource;
 
 import java.util.List;
 
@@ -80,6 +79,7 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
 
     public static class Client implements HexConfig.ClientConfigAccess {
         private static ForgeConfigSpec.BooleanValue ctrlTogglesOffStrokeOrder;
+        private static ForgeConfigSpec.BooleanValue disableInworldScrolling;
         private static ForgeConfigSpec.BooleanValue invertSpellbookScrollDirection;
         private static ForgeConfigSpec.BooleanValue invertAbacusScrollDirection;
         private static ForgeConfigSpec.DoubleValue gridSnapThreshold;
@@ -90,6 +90,9 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
             ctrlTogglesOffStrokeOrder = builder.comment(
                     "Whether the ctrl key will instead turn *off* the color gradient on patterns")
                 .define("ctrlTogglesOffStrokeOrder", DEFAULT_CTRL_TOGGLES_OFF_STROKE_ORDER);
+            disableInworldScrolling = builder.comment(
+                    "Disable scrolling input for spellbooks and abaci in the normal world, keeping keybinds and staff screen scrolling normal")
+                .define("disableInworldScrolling", DEFAULT_DISABLE_INWORLD_SCROLLING);
             invertSpellbookScrollDirection = builder.comment(
                     "Whether scrolling up (as opposed to down) will increase the page index of the spellbook, and " +
                         "vice versa")
@@ -107,6 +110,11 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
             alwaysShowListCommas = builder.comment(
                             "Whether all iota types should be comma-separated in lists (by default, pattern iotas don't use commas)")
                     .define("alwaysShowListCommas", DEFAULT_ALWAYS_SHOW_LIST_COMMAS);
+        }
+
+        @Override
+        public boolean disableInworldScrolling() {
+            return disableInworldScrolling.get();
         }
 
         @Override


### PR DESCRIPTION
This PR includes two changes:
- Keybinds (unbound by default) for switching spellbook pages (closes #373)
- Clientside config setting to disable in-world scrolling of spellbooks and abaci
  - Changes supersede #1018 and #1019, which I did not know existed until moments ago
  - Fixes invertAbacusScrollDirection's fabric tooltip to describe changing the "value" rather than "page index"