### PR TITLE
Allow overwriting akashic libraries (1.19)

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/common/blocks/akashic/BlockAkashicRecord.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/blocks/akashic/BlockAkashicRecord.java
@@ -22,24 +22,25 @@ public class BlockAkashicRecord extends Block {
      */
     public @Nullable
     BlockPos addNewDatum(BlockPos herePos, Level level, HexPattern key, Iota datum) {
-        var clobbereePos = AkashicFloodfiller.floodFillFor(herePos, level,
+        // Look for existing shelf with the same pattern to overwrite
+        var targetPos = AkashicFloodfiller.floodFillFor(herePos, level,
             (pos, bs, world) ->
                 world.getBlockEntity(pos) instanceof BlockEntityAkashicBookshelf tile
                     && tile.getPattern() != null && tile.getPattern().sigsEqual(key));
 
-        if (clobbereePos != null) {
-            return null;
+        if (targetPos == null) {
+            // Otherwise find an empty shelf
+            targetPos = AkashicFloodfiller.floodFillFor(herePos, level, 0.9f,
+                (pos, bs, world) ->
+                    world.getBlockEntity(pos) instanceof BlockEntityAkashicBookshelf tile
+                        && tile.getPattern() == null, 128);
         }
 
-        var openPos = AkashicFloodfiller.floodFillFor(herePos, level, 0.9f,
-            (pos, bs, world) ->
-                world.getBlockEntity(pos) instanceof BlockEntityAkashicBookshelf tile
-                    && tile.getPattern() == null, 128);
-        if (openPos != null) {
-            var tile = (BlockEntityAkashicBookshelf) level.getBlockEntity(openPos);
+        if (targetPos != null) {
+            var tile = (BlockEntityAkashicBookshelf) level.getBlockEntity(targetPos);
             tile.setNewMapping(key, datum);
 
-            return openPos;
+            return targetPos;
         } else {
             return null;
         }

--- a/Common/src/main/java/at/petrak/hexcasting/common/blocks/akashic/BlockEntityAkashicBookshelf.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/blocks/akashic/BlockEntityAkashicBookshelf.java
@@ -40,12 +40,13 @@ public class BlockEntityAkashicBookshelf extends HexBlockEntity {
         this.pattern = pattern;
         this.iotaTag = HexIotaTypes.serialize(iota);
 
+        var oldBs = this.getBlockState();
         if (previouslyEmpty) {
-            var oldBs = this.getBlockState();
             var newBs = oldBs.setValue(BlockAkashicBookshelf.HAS_BOOKS, true);
-            this.level.setBlock(this.getBlockPos(), newBs, 3);
             this.level.sendBlockUpdated(this.getBlockPos(), oldBs, newBs, 3);
+            this.level.setBlock(this.getBlockPos(), newBs, 3);
         } else {
+            this.level.sendBlockUpdated(this.getBlockPos(), oldBs, oldBs, 3);
             this.setChanged();
         }
     }


### PR DESCRIPTION
Allows overwriting existing pattern keys in akashic libraries.
Marked as draft due to problems, see below.

Cherry-pick of #1090 to the 1.19 branch.