### PR TITLE
feat: automatically fix 1.20 items when switching to 1.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added Simulate, which causes the next pattern drawn to be simulated (to check for mishaps) rather than executed ([#1194](https://github.com/FallingColors/HexMod/pull/1194)) @Robotgiggle
 - Added the `hex_unbreakable` tag for blocks that should be immune to Break Block regardless of the configured mining tier ([#1186](https://github.com/FallingColors/HexMod/pull/1186)) @Robotgiggle @slava110
 - Added a new Ancient Cypher hex that impulses nearby items towards the caster ([#1106](https://github.com/FallingColors/HexMod/pull/1106)) @IridescentVoid
+- Added automatic item fixing for items carried over from 1.20.x (might not work on items stored inside modded containers) ([#1226](https://github.com/FallingColors/HexMod/pull/1226)) @Olfi01
 
 ### Changed
 

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/iota/EntityIota.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/iota/EntityIota.java
@@ -28,7 +28,7 @@ import java.util.UUID;
 public class EntityIota extends Iota {
     private final UUID entityId;
     @Nullable
-    private final Component entityName;
+    private Component entityName;
     private boolean isPlayer;
 
     public EntityIota(@NotNull Entity e) {
@@ -115,6 +115,8 @@ public class EntityIota extends Iota {
             var entity = iota.getEntity(level);
             // update isPlayer so older non-player entity iotas are not protected
             iota.isPlayer = (entity instanceof Player);
+            if (iota.entityName == null)
+                iota.entityName = getEntityNameWithInline(entity);
             return entity != null;
         }
 

--- a/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
+++ b/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
@@ -21,8 +21,6 @@ public class MixinItemStackComponentizationFix {
     @Unique
     private static final String HEX_TYPE = "hexcasting:type";
     @Unique
-    private static final String HEX_STORAGE_SEALED = "hexcasting:sealed";
-    @Unique
     private static final String HEX_DATA = "hexcasting:data";
 
     @Inject(method = "fixItemStack", at = @At("TAIL"))
@@ -55,7 +53,7 @@ public class MixinItemStackComponentizationFix {
         itemStackData.fixSubTag("data", true, MixinItemStackComponentizationFix::hexCasting$mapIotaData);
         itemStackData.moveTagToComponent("data", "hexcasting:iota");
 
-        if (itemStackData.removeTag(HEX_STORAGE_SEALED).asBoolean(false))
+        if (itemStackData.removeTag("sealed").asBoolean(false))
             itemStackData.setComponent("hexcasting:sealed", dynamic.createMap(Map.of()));
     }
 
@@ -72,8 +70,7 @@ public class MixinItemStackComponentizationFix {
                 component.put(iota.createString("entityId"), iota.createIntList(uuid));
                 component.put(iota.createString("isPlayer"), iota.createBoolean(true));
                 break;
-            case "hexcasting:boolean":
-            case "hexcasting:double":
+            case "hexcasting:boolean", "hexcasting:double":
                 component.put(iota.createString("value"), iotaData);
                 break;
             case "hexcasting:list":
@@ -90,8 +87,7 @@ public class MixinItemStackComponentizationFix {
                 component.put(iota.createString("value"),
                         iota.createList(iotaData.asStream().map(MixinItemStackComponentizationFix::hexCasting$mapContinuationFrame)));
                 break;
-            case "hexcasting:null":
-            case "hexcasting:garbage":
+            case "hexcasting:null", "hexcasting:garbage":
             default:
                 break;
         }

--- a/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
+++ b/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
@@ -43,6 +43,9 @@ public class MixinItemStackComponentizationFix {
     private static void fixHexItemStack(ItemStackData itemStackData, Dynamic<?> dynamic, CallbackInfo ci) {
         Item item = BuiltInRegistries.ITEM.get(ResourceLocation.parse(itemStackData.item));
 
+        if (itemStackData.is("patchouli:guide_book")) {
+            itemStackData.moveTagToComponent("patchouli:book", "patchouli:book");
+        }
         if (itemStackData.is(Set.of("hexcasting:focus", "hexcasting:thought_knot"))) {
             hexCasting$fixIotaHolder(itemStackData, dynamic);
         }

--- a/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
+++ b/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
@@ -1,21 +1,49 @@
 package at.petrak.hexcasting.mixin.datafixer;
 
 import com.mojang.serialization.Dynamic;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import net.minecraft.util.datafix.fixes.ItemStackComponentizationFix;
+import net.minecraft.util.datafix.fixes.ItemStackComponentizationFix.ItemStackData;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ItemStackComponentizationFix.class)
 public class MixinItemStackComponentizationFix {
+    private static final String HEX_IOTA_COMPONENT = "hexcasting:iota";
+    private static final String HEX_IOTA_TYPE = "hexcasting:type";
+    private static final String HEX_STORAGE_SEALED = "hexcasting:sealed";
+    private static final String HEX_DATA = "hexcasting:data";
+
     @Inject(method = "fixItemStack", at = @At("TAIL"))
-    private static void fixHexItemStack(ItemStackComponentizationFix.ItemStackData itemStackData, Dynamic<?> dynamic, CallbackInfo ci) {
-        if (itemStackData.is("hexcasting:focus")) {
-            Map<String, Dynamic<?>> data = itemStackData.removeTag("data").asMap((dynamicx) -> dynamicx.asString(""), (dynamicx) -> dynamicx);
-            Dynamic<?> component = dynamic.createMap(Map.of(dynamic.createString("type"), data.get("hexcasting:type"), dynamic.createString("value"), data.get("hexcasting:data")));
-            itemStackData.setComponent("hexcasting:iota", component);
+    private static void fixHexItemStack(ItemStackData itemStackData, Dynamic<?> dynamic, CallbackInfo ci) {
+        if (itemStackData.is(Set.of("hexcasting:focus", "hexcasting:thought_knot"))) {
+            Map<String, Dynamic<?>> data =
+                itemStackData
+                    .removeTag("data")
+                    .asMap((dynamicx) -> dynamicx.asString(""), (dynamicx) -> dynamicx);
+            if (data.containsKey(HEX_DATA) && data.containsKey(HEX_IOTA_TYPE)) {
+              hexCasting$fixIotaHolder(
+                  itemStackData,
+                  dynamic,
+                  data.remove(HEX_IOTA_TYPE).asString(""),
+                  data.remove(HEX_DATA),
+                  data.remove(HEX_STORAGE_SEALED).asBoolean(false));
+            }
         }
+    }
+
+
+    @Unique
+    private static void hexCasting$fixIotaHolder(ItemStackData itemStackData, Dynamic<?> dynamic, String iotaType, Dynamic<?> hexData, boolean sealed) {
+        Map<Dynamic<?>, Dynamic<?>> component = new HashMap<>();
+        component.put(dynamic.createString("type"), dynamic.createString(iotaType));
+        component.put(dynamic.createString("value"), hexData);
+        if (sealed) component.put(dynamic.createString("sealed"), dynamic.createBoolean(true));
+        itemStackData.setComponent(HEX_IOTA_COMPONENT, dynamic.createMap(component));
     }
 }

--- a/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
+++ b/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
@@ -4,6 +4,7 @@ import at.petrak.hexcasting.api.casting.math.HexPattern;
 import com.mojang.serialization.Dynamic;
 
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -160,6 +161,11 @@ public class MixinItemStackComponentizationFix {
     }
 
     @Unique
+    private static Dynamic<?> hexCasting$stringToPlainComponent(Dynamic<?> string) {
+        return string.createMap(Map.of(string.createString("text"), string));
+    }
+
+    @Unique
     private static void hexCasting$fixScroll(ItemStackData itemStackData) {
         itemStackData.fixSubTag("pattern", true, MixinItemStackComponentizationFix::hexCasting$mapPattern);
 
@@ -171,6 +177,16 @@ public class MixinItemStackComponentizationFix {
 
     @Unique
     private static void hexCasting$fixSpellbook(ItemStackData itemStackData, Dynamic<?> dynamic) {
-        // TODO: all spellbook components
+        itemStackData.moveTagToComponent("page_idx", "hexcasting:page_idx");
+
+        itemStackData.fixSubTag("page_names", true, d0 ->
+            d0.createMap(d0.asMap(Function.identity(), MixinItemStackComponentizationFix::hexCasting$stringToPlainComponent)));
+        itemStackData.moveTagToComponent("page_names", "hexcasting:page_names");
+
+        itemStackData.fixSubTag("pages", true, d0 ->
+            d0.createMap(d0.asMap(Function.identity(), MixinItemStackComponentizationFix::hexCasting$mapPattern)));
+        itemStackData.moveTagToComponent("pages", "hexcasting:pages");
+
+        itemStackData.moveTagToComponent("sealed_pages", "hexcasting:sealed_pages");
     }
 }

--- a/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
+++ b/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
@@ -45,7 +45,7 @@ public class MixinItemStackComponentizationFix {
             hexCasting$fixScroll(itemStackData, dynamic);
         }
         if (itemStackData.is("hexcasting:ancient_cypher")) {
-            // TODO: hex name component
+            itemStackData.moveTagToComponent("hex_name", "hexcasting:hex_name");
         }
         if (itemStackData.is("hexcasting:abacus")) {
             // TODO: abacus value component

--- a/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
+++ b/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
@@ -35,7 +35,7 @@ public class MixinItemStackComponentizationFix {
         if (itemStackData.is("hexcasting:slate")) {
             itemStackData.fixSubTag("BlockEntityTag", false, dynamic0 ->
                     hexCasting$mapPattern(dynamic0.get("pattern").orElseEmptyMap()));
-            itemStackData.moveTagToComponent("BlockEntityTag", "pattern");
+            itemStackData.moveTagToComponent("BlockEntityTag", "hexcasting:pattern");
         }
     }
 
@@ -200,7 +200,7 @@ public class MixinItemStackComponentizationFix {
         itemStackData.moveTagToComponent("page_names", "hexcasting:page_names");
 
         itemStackData.fixSubTag("pages", true, d0 ->
-            d0.createMap(d0.asMap(Function.identity(), MixinItemStackComponentizationFix::hexCasting$mapPattern)));
+            d0.createMap(d0.asMap(Function.identity(), MixinItemStackComponentizationFix::hexCasting$mapIotaData)));
         itemStackData.moveTagToComponent("pages", "hexcasting:pages");
 
         itemStackData.moveTagToComponent("sealed_pages", "hexcasting:sealed_pages");

--- a/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
+++ b/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
@@ -9,7 +9,6 @@ import java.util.stream.Stream;
 
 import net.minecraft.util.datafix.fixes.ItemStackComponentizationFix;
 import net.minecraft.util.datafix.fixes.ItemStackComponentizationFix.ItemStackData;
-import org.apache.commons.lang3.NotImplementedException;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -22,6 +21,15 @@ public class MixinItemStackComponentizationFix {
     private static final String HEX_TYPE = "hexcasting:type";
     @Unique
     private static final String HEX_DATA = "hexcasting:data";
+
+    @Inject(method = "fixItemStack", at = @At("HEAD"))
+    private static void preFixHexItemStack(ItemStackData itemStackData, Dynamic<?> dynamic, CallbackInfo ci) {
+        if (itemStackData.is("hexcasting:slate")) {
+            itemStackData.fixSubTag("BlockEntityTag", false, dynamic0 ->
+                    hexCasting$mapPattern(dynamic0.get("pattern").orElseEmptyMap()));
+            itemStackData.moveTagToComponent("BlockEntityTag", "pattern");
+        }
+    }
 
     @Inject(method = "fixItemStack", at = @At("TAIL"))
     private static void fixHexItemStack(ItemStackData itemStackData, Dynamic<?> dynamic, CallbackInfo ci) {

--- a/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
+++ b/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
@@ -2,6 +2,7 @@ package at.petrak.hexcasting.mixin.datafixer;
 
 import at.petrak.hexcasting.api.casting.math.HexPattern;
 import at.petrak.hexcasting.api.item.IotaHolderItem;
+import at.petrak.hexcasting.api.item.VariantItem;
 import com.mojang.serialization.Dynamic;
 
 import java.util.*;
@@ -58,7 +59,9 @@ public class MixinItemStackComponentizationFix {
         if (item instanceof IotaHolderItem) {
             itemStackData.moveTagToComponent("VisualOverride", "hexcasting:visual_override");
         }
-        // TODO: item variant component
+        if (item instanceof VariantItem) {
+            itemStackData.moveTagToComponent("variant", "hexcasting:variant");
+        }
         // TODO: wait for #1220, then hex holder component
         // TODO: media component
         // TODO: media_max component

--- a/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
+++ b/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
@@ -3,6 +3,8 @@ package at.petrak.hexcasting.mixin.datafixer;
 import at.petrak.hexcasting.api.casting.math.HexPattern;
 import at.petrak.hexcasting.api.item.IotaHolderItem;
 import at.petrak.hexcasting.api.item.VariantItem;
+import at.petrak.hexcasting.common.items.magic.ItemMediaHolder;
+import at.petrak.hexcasting.common.items.magic.ItemPackagedHex;
 import com.mojang.serialization.Dynamic;
 
 import java.util.*;
@@ -62,9 +64,13 @@ public class MixinItemStackComponentizationFix {
         if (item instanceof VariantItem) {
             itemStackData.moveTagToComponent("variant", "hexcasting:variant");
         }
-        // TODO: wait for #1220, then hex holder component
-        // TODO: media component
-        // TODO: media_max component
+        if (item instanceof ItemPackagedHex) {
+            // TODO: wait for #1220, then hex holder component
+        }
+        if (item instanceof ItemMediaHolder) {
+            itemStackData.moveTagToComponent("hexcasting:media", "hexcasting:media");
+            itemStackData.moveTagToComponent("hexcasting:start_media", "hexcasting:start_media");
+        }
     }
 
     @Unique

--- a/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
+++ b/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
@@ -35,7 +35,7 @@ public class MixinItemStackComponentizationFix {
             itemStackData.moveTagToComponent("hex_name", "hexcasting:hex_name");
         }
         if (itemStackData.is("hexcasting:abacus")) {
-            // TODO: abacus value component
+            itemStackData.moveTagToComponent("value", "hexcasting:abacus_value");
         }
         if (itemStackData.is("hexcasting:spellbook")) {
             hexCasting$fixSpellbook(itemStackData, dynamic);

--- a/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
+++ b/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
@@ -15,6 +15,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(ItemStackComponentizationFix.class)
 public class MixinItemStackComponentizationFix {
     private static final String HEX_IOTA_COMPONENT = "hexcasting:iota";
+    private static final String HEX_SEALED_COMPONENT = "hexcasting:sealed";
     private static final String HEX_IOTA_TYPE = "hexcasting:type";
     private static final String HEX_STORAGE_SEALED = "hexcasting:sealed";
     private static final String HEX_DATA = "hexcasting:data";
@@ -43,7 +44,7 @@ public class MixinItemStackComponentizationFix {
         Map<Dynamic<?>, Dynamic<?>> component = new HashMap<>();
         component.put(dynamic.createString("type"), dynamic.createString(iotaType));
         component.put(dynamic.createString("value"), hexData);
-        if (sealed) component.put(dynamic.createString("sealed"), dynamic.createBoolean(true));
         itemStackData.setComponent(HEX_IOTA_COMPONENT, dynamic.createMap(component));
+        if (sealed) itemStackData.setComponent(HEX_SEALED_COMPONENT, dynamic.createMap(Map.of()));
     }
 }

--- a/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
+++ b/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
@@ -4,7 +4,6 @@ import at.petrak.hexcasting.api.casting.math.HexPattern;
 import com.mojang.serialization.Dynamic;
 
 import java.util.*;
-import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -20,7 +19,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(ItemStackComponentizationFix.class)
 public class MixinItemStackComponentizationFix {
     @Unique
-    private static final String HEX_IOTA_TYPE = "hexcasting:type";
+    private static final String HEX_TYPE = "hexcasting:type";
     @Unique
     private static final String HEX_STORAGE_SEALED = "hexcasting:sealed";
     @Unique
@@ -62,7 +61,7 @@ public class MixinItemStackComponentizationFix {
 
     @Unique
     private static Dynamic<?> hexCasting$mapIotaData(Dynamic<?> iota) {
-        String iotaType = iota.get(HEX_IOTA_TYPE).asString("");
+        String iotaType = iota.get(HEX_TYPE).asString("");
         Dynamic<?> iotaData = iota.get(HEX_DATA).orElseEmptyMap();
         Map<Dynamic<?>, Dynamic<?>> component = new HashMap<>();
         component.put(iota.createString("type"), iota.createString(iotaType));
@@ -78,8 +77,8 @@ public class MixinItemStackComponentizationFix {
                 component.put(iota.createString("value"), iotaData);
                 break;
             case "hexcasting:list":
-                List<Dynamic<?>> listData = iotaData.asList(MixinItemStackComponentizationFix::hexCasting$mapIotaData);
-                component.put(iota.createString("list"), iota.createList(listData.stream()));
+                component.put(iota.createString("list"),
+                        iota.createList(iotaData.asStream().map(MixinItemStackComponentizationFix::hexCasting$mapIotaData)));
                 break;
             case "hexcasting:pattern":
                 component.put(iota.createString("value"), hexCasting$mapPattern(iotaData));
@@ -88,8 +87,8 @@ public class MixinItemStackComponentizationFix {
                 component.put(iota.createString("value"), hexCasting$mapVec3(iotaData));
                 break;
             case "hexcasting:continuation":
-                List<Dynamic<?>> frames = iotaData.asList(MixinItemStackComponentizationFix::hexCasting$mapContinuationFrame);
-                component.put(iota.createString("value"), iota.createList(frames.stream()));
+                component.put(iota.createString("value"),
+                        iota.createList(iotaData.asStream().map(MixinItemStackComponentizationFix::hexCasting$mapContinuationFrame)));
                 break;
             case "hexcasting:null":
             case "hexcasting:garbage":
@@ -107,9 +106,11 @@ public class MixinItemStackComponentizationFix {
     private static Dynamic<?> hexCasting$mapPattern(Dynamic<?> pattern) {
         Map<Dynamic<?>, Dynamic<?>> patternComponent = new HashMap<>();
         byte startDir = pattern.get("start_dir").asByte((byte) 0);
-        List<Byte> angles = pattern.get("angles").asList(dynamic0 -> dynamic0.asByte((byte) 0));
+        List<String> angles = pattern.get("angles").asStream()
+                .map(a -> hexCasting$hexAngle[a.asByte((byte) 0)])
+                .toList();
         patternComponent.put(pattern.createString(HexPattern.TAG_START_DIR), pattern.createString(hexCasting$hexDir[startDir]));
-        patternComponent.put(pattern.createString(HexPattern.TAG_ANGLES), pattern.createString(String.join("", angles.stream().map(a -> hexCasting$hexAngle[a]).toList())));
+        patternComponent.put(pattern.createString(HexPattern.TAG_ANGLES), pattern.createString(String.join("", angles)));
         return pattern.createMap(patternComponent);
     }
 
@@ -122,8 +123,36 @@ public class MixinItemStackComponentizationFix {
     }
 
     @Unique
-    private static Dynamic<?> hexCasting$mapContinuationFrame(Dynamic<?> dynamic) {
-        throw new NotImplementedException();
+    private static Dynamic<?> hexCasting$mapContinuationFrame(Dynamic<?> frame) {
+        String type = frame.get(HEX_TYPE).asString("");
+        Dynamic<?> frameData = frame.get(HEX_DATA).orElseEmptyMap();
+        Map<Dynamic<?>, Dynamic<?>> component = new HashMap<>();
+        component.put(frame.createString("type"), frame.createString(type));
+        switch (type) {
+            case "hexcasting:evaluate":
+                component.put(frame.createString("patterns"),
+                        frame.createList(frameData.get("patterns").asStream().map(MixinItemStackComponentizationFix::hexCasting$mapIotaData)));
+                component.put(frame.createString("isMetacasting"),
+                        frame.createBoolean(frameData.get("isMetacasting").asBoolean(false)));
+                break;
+            case "hexcasting:foreach":
+                component.put(frame.createString("data"),
+                        frame.createList(frameData.get("data").asStream().map(MixinItemStackComponentizationFix::hexCasting$mapIotaData)));
+                component.put(frame.createString("code"),
+                        frame.createList(frameData.get("code").asStream().map(MixinItemStackComponentizationFix::hexCasting$mapIotaData)));
+                component.put(frame.createString("context"),
+                        frame.createList(frameData.get("base").asStream().map(MixinItemStackComponentizationFix::hexCasting$mapIotaData)));
+                // TODO: figure out whether stashed should be base (replicating otherwise unavailable 1.20 thoth behavior) or an empty list (equivalent to 1.21 thoth with whatever size the stack had before casting)
+                component.put(frame.createString("stashed"),
+                        frame.createList(frameData.get("base").asStream().map(MixinItemStackComponentizationFix::hexCasting$mapIotaData)));
+                component.put(frame.createString("accumulator"),
+                        frame.createList(frameData.get("accumulator").asStream().map(MixinItemStackComponentizationFix::hexCasting$mapIotaData)));
+                break;
+            case "hexcasting:end":
+            default:
+                break;
+        }
+        return frame.createMap(component);
     }
 
     @Unique

--- a/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
+++ b/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
@@ -4,8 +4,8 @@ import at.petrak.hexcasting.api.casting.math.HexPattern;
 import com.mojang.serialization.Dynamic;
 
 import java.util.*;
+import java.util.stream.IntStream;
 
-import com.mojang.serialization.OptionalDynamic;
 import net.minecraft.util.datafix.fixes.ItemStackComponentizationFix;
 import net.minecraft.util.datafix.fixes.ItemStackComponentizationFix.ItemStackData;
 import org.spongepowered.asm.mixin.Mixin;
@@ -66,6 +66,12 @@ public class MixinItemStackComponentizationFix {
         switch (iotaType) {
             case "hexcasting:double":
                 component.put(dynamic.createString("value"), hexData);
+                break;
+            case "hexcasting:entity":
+                IntStream uuid = hexData.get("uuid").asIntStream();
+                // Unfortunately, it seems like we cannot easily fix InlineAPI components, so we will have to live with "an unknown entity"
+                component.put(dynamic.createString("entityId"), dynamic.createIntList(uuid));
+                component.put(dynamic.createString("isPlayer"), dynamic.createBoolean(true));
                 break;
                 // TODO: correctly fix each iota type. Can we somehow even do this for non-basemod iotas?
         }

--- a/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
+++ b/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
@@ -1,9 +1,13 @@
 package at.petrak.hexcasting.mixin.datafixer;
 
+import at.petrak.hexcasting.api.casting.math.HexPattern;
 import com.mojang.serialization.Dynamic;
+
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import net.minecraft.util.datafix.fixes.ItemStackComponentizationFix;
 import net.minecraft.util.datafix.fixes.ItemStackComponentizationFix.ItemStackData;
 import org.spongepowered.asm.mixin.Mixin;
@@ -14,37 +18,80 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ItemStackComponentizationFix.class)
 public class MixinItemStackComponentizationFix {
-    private static final String HEX_IOTA_COMPONENT = "hexcasting:iota";
-    private static final String HEX_SEALED_COMPONENT = "hexcasting:sealed";
+    @Unique
     private static final String HEX_IOTA_TYPE = "hexcasting:type";
+    @Unique
     private static final String HEX_STORAGE_SEALED = "hexcasting:sealed";
+    @Unique
     private static final String HEX_DATA = "hexcasting:data";
 
     @Inject(method = "fixItemStack", at = @At("TAIL"))
     private static void fixHexItemStack(ItemStackData itemStackData, Dynamic<?> dynamic, CallbackInfo ci) {
         if (itemStackData.is(Set.of("hexcasting:focus", "hexcasting:thought_knot"))) {
             Map<String, Dynamic<?>> data =
-                itemStackData
-                    .removeTag("data")
-                    .asMap((dynamicx) -> dynamicx.asString(""), (dynamicx) -> dynamicx);
+                    itemStackData
+                            .removeTag("data")
+                            .asMap((dynamicx) -> dynamicx.asString(""), (dynamicx) -> dynamicx);
             if (data.containsKey(HEX_DATA) && data.containsKey(HEX_IOTA_TYPE)) {
-              hexCasting$fixIotaHolder(
-                  itemStackData,
-                  dynamic,
-                  data.remove(HEX_IOTA_TYPE).asString(""),
-                  data.remove(HEX_DATA),
-                  data.remove(HEX_STORAGE_SEALED).asBoolean(false));
+                hexCasting$fixIotaHolder(
+                        itemStackData,
+                        dynamic,
+                        data.get(HEX_IOTA_TYPE).asString(""),
+                        data.get(HEX_DATA),
+                        data.containsKey(HEX_STORAGE_SEALED) && data.get(HEX_STORAGE_SEALED).asBoolean(false));
             }
         }
-    }
+        if (itemStackData.is(Set.of("hexcasting:scroll_small", "hexcasting:scroll_medium", "hexcasting:scroll"))) {
+            hexCasting$fixScroll(itemStackData, dynamic);
+        }
+        if (itemStackData.is("hexcasting:ancient_cypher")) {
+            // TODO: hex name component
+        }
+        if (itemStackData.is("hexcasting:abacus")) {
+            // TODO: abacus value component
+        }
+        if (itemStackData.is("hexcasting:spellbook")) {
+            hexCasting$fixSpellbook(itemStackData, dynamic);
+        }
 
+        // TODO: visual override component
+        // TODO: item variant component
+        // TODO: wait for #1220, then hex holder component
+        // TODO: media component
+        // TODO: media_max component
+    }
 
     @Unique
     private static void hexCasting$fixIotaHolder(ItemStackData itemStackData, Dynamic<?> dynamic, String iotaType, Dynamic<?> hexData, boolean sealed) {
         Map<Dynamic<?>, Dynamic<?>> component = new HashMap<>();
         component.put(dynamic.createString("type"), dynamic.createString(iotaType));
         component.put(dynamic.createString("value"), hexData);
-        itemStackData.setComponent(HEX_IOTA_COMPONENT, dynamic.createMap(component));
-        if (sealed) itemStackData.setComponent(HEX_SEALED_COMPONENT, dynamic.createMap(Map.of()));
+        itemStackData.setComponent("hexcasting:iota", dynamic.createMap(component));
+        if (sealed) itemStackData.setComponent("hexcasting:sealed", dynamic.createMap(Map.of()));
+    }
+
+    @Unique
+    private static final String[] hexCasting$hexDir = {"NORTH_EAST", "EAST", "SOUTH_EAST", "SOUTH_WEST", "WEST", "NORTH_WEST"};
+    @Unique
+    private static final String[] hexCasting$hexAngle = {"w", "e", "d", "s", "a", "q"};
+
+    @Unique
+    private static void hexCasting$fixScroll(ItemStackData itemStackData, Dynamic<?> dynamic) {
+        Dynamic<?> pattern = itemStackData.removeTag("pattern").orElseEmptyMap();
+        byte startDir = pattern.get("start_dir").asByte((byte) 0);
+        List<Byte> angles = pattern.get("angles").asList(dynamic0 -> dynamic0.asByte((byte) 0));
+        Map<Dynamic<?>, Dynamic<?>> patternComponent = new HashMap<>();
+        patternComponent.put(dynamic.createString(HexPattern.TAG_START_DIR), dynamic.createString(hexCasting$hexDir[startDir]));
+        patternComponent.put(dynamic.createString(HexPattern.TAG_ANGLES), dynamic.createString(String.join("", angles.stream().map(a -> hexCasting$hexAngle[a]).toList())));
+        itemStackData.setComponent("hexcasting:pattern", dynamic.createMap(patternComponent));
+
+        itemStackData.moveTagToComponent("op_id", "hexcasting:op_id");
+        itemStackData.moveTagToComponent("recalc_warning", "hexcasting:recalc_warning");
+        itemStackData.moveTagToComponent("needs_purchase", "hexcasting:needs_purchase");
+    }
+
+    @Unique
+    private static void hexCasting$fixSpellbook(ItemStackData itemStackData, Dynamic<?> dynamic) {
+        // TODO: all spellbook components
     }
 }

--- a/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
+++ b/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
@@ -3,11 +3,9 @@ package at.petrak.hexcasting.mixin.datafixer;
 import at.petrak.hexcasting.api.casting.math.HexPattern;
 import com.mojang.serialization.Dynamic;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
+import com.mojang.serialization.OptionalDynamic;
 import net.minecraft.util.datafix.fixes.ItemStackComponentizationFix;
 import net.minecraft.util.datafix.fixes.ItemStackComponentizationFix.ItemStackData;
 import org.spongepowered.asm.mixin.Mixin;
@@ -65,6 +63,12 @@ public class MixinItemStackComponentizationFix {
     private static void hexCasting$fixIotaHolder(ItemStackData itemStackData, Dynamic<?> dynamic, String iotaType, Dynamic<?> hexData, boolean sealed) {
         Map<Dynamic<?>, Dynamic<?>> component = new HashMap<>();
         component.put(dynamic.createString("type"), dynamic.createString(iotaType));
+        switch (iotaType) {
+            case "hexcasting:double":
+                component.put(dynamic.createString("value"), hexData);
+                break;
+                // TODO: correctly fix each iota type. Can we somehow even do this for non-basemod iotas?
+        }
         component.put(dynamic.createString("value"), hexData);
         itemStackData.setComponent("hexcasting:iota", dynamic.createMap(component));
         if (sealed) itemStackData.setComponent("hexcasting:sealed", dynamic.createMap(Map.of()));

--- a/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
+++ b/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
@@ -1,6 +1,7 @@
 package at.petrak.hexcasting.mixin.datafixer;
 
 import at.petrak.hexcasting.api.casting.math.HexPattern;
+import at.petrak.hexcasting.api.item.IotaHolderItem;
 import com.mojang.serialization.Dynamic;
 
 import java.util.*;
@@ -8,8 +9,11 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.datafix.fixes.ItemStackComponentizationFix;
 import net.minecraft.util.datafix.fixes.ItemStackComponentizationFix.ItemStackData;
+import net.minecraft.world.item.Item;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -34,6 +38,8 @@ public class MixinItemStackComponentizationFix {
 
     @Inject(method = "fixItemStack", at = @At("TAIL"))
     private static void fixHexItemStack(ItemStackData itemStackData, Dynamic<?> dynamic, CallbackInfo ci) {
+        Item item = BuiltInRegistries.ITEM.get(ResourceLocation.parse(itemStackData.item));
+
         if (itemStackData.is(Set.of("hexcasting:focus", "hexcasting:thought_knot"))) {
             hexCasting$fixIotaHolder(itemStackData, dynamic);
         }
@@ -49,8 +55,9 @@ public class MixinItemStackComponentizationFix {
         if (itemStackData.is("hexcasting:spellbook")) {
             hexCasting$fixSpellbook(itemStackData, dynamic);
         }
-
-        // TODO: visual override component
+        if (item instanceof IotaHolderItem) {
+            itemStackData.moveTagToComponent("VisualOverride", "hexcasting:visual_override");
+        }
         // TODO: item variant component
         // TODO: wait for #1220, then hex holder component
         // TODO: media component

--- a/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
+++ b/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
@@ -163,9 +163,8 @@ public class MixinItemStackComponentizationFix {
                         frame.createList(frameData.get("code").asStream().map(MixinItemStackComponentizationFix::hexCasting$mapIotaData)));
                 component.put(frame.createString("context"),
                         frame.createList(frameData.get("base").asStream().map(MixinItemStackComponentizationFix::hexCasting$mapIotaData)));
-                // TODO: figure out whether stashed should be base (replicating otherwise unavailable 1.20 thoth behavior) or an empty list (equivalent to 1.21 thoth with whatever size the stack had before casting)
                 component.put(frame.createString("stashed"),
-                        frame.createList(frameData.get("base").asStream().map(MixinItemStackComponentizationFix::hexCasting$mapIotaData)));
+                        frame.createList(Stream.of()));
                 component.put(frame.createString("accumulator"),
                         frame.createList(frameData.get("accumulator").asStream().map(MixinItemStackComponentizationFix::hexCasting$mapIotaData)));
                 break;

--- a/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
+++ b/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
@@ -4,10 +4,13 @@ import at.petrak.hexcasting.api.casting.math.HexPattern;
 import com.mojang.serialization.Dynamic;
 
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import net.minecraft.util.datafix.fixes.ItemStackComponentizationFix;
 import net.minecraft.util.datafix.fixes.ItemStackComponentizationFix.ItemStackData;
+import org.apache.commons.lang3.NotImplementedException;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -26,21 +29,10 @@ public class MixinItemStackComponentizationFix {
     @Inject(method = "fixItemStack", at = @At("TAIL"))
     private static void fixHexItemStack(ItemStackData itemStackData, Dynamic<?> dynamic, CallbackInfo ci) {
         if (itemStackData.is(Set.of("hexcasting:focus", "hexcasting:thought_knot"))) {
-            Map<String, Dynamic<?>> data =
-                    itemStackData
-                            .removeTag("data")
-                            .asMap((dynamicx) -> dynamicx.asString(""), (dynamicx) -> dynamicx);
-            if (data.containsKey(HEX_DATA) && data.containsKey(HEX_IOTA_TYPE)) {
-                hexCasting$fixIotaHolder(
-                        itemStackData,
-                        dynamic,
-                        data.get(HEX_IOTA_TYPE).asString(""),
-                        data.get(HEX_DATA),
-                        data.containsKey(HEX_STORAGE_SEALED) && data.get(HEX_STORAGE_SEALED).asBoolean(false));
-            }
+            hexCasting$fixIotaHolder(itemStackData, dynamic);
         }
         if (itemStackData.is(Set.of("hexcasting:scroll_small", "hexcasting:scroll_medium", "hexcasting:scroll"))) {
-            hexCasting$fixScroll(itemStackData, dynamic);
+            hexCasting$fixScroll(itemStackData);
         }
         if (itemStackData.is("hexcasting:ancient_cypher")) {
             itemStackData.moveTagToComponent("hex_name", "hexcasting:hex_name");
@@ -60,41 +52,85 @@ public class MixinItemStackComponentizationFix {
     }
 
     @Unique
-    private static void hexCasting$fixIotaHolder(ItemStackData itemStackData, Dynamic<?> dynamic, String iotaType, Dynamic<?> hexData, boolean sealed) {
+    private static void hexCasting$fixIotaHolder(ItemStackData itemStackData, Dynamic<?> dynamic) {
+        itemStackData.fixSubTag("data", true, MixinItemStackComponentizationFix::hexCasting$mapIotaData);
+        itemStackData.moveTagToComponent("data", "hexcasting:iota");
+
+        if (itemStackData.removeTag(HEX_STORAGE_SEALED).asBoolean(false))
+            itemStackData.setComponent("hexcasting:sealed", dynamic.createMap(Map.of()));
+    }
+
+    @Unique
+    private static Dynamic<?> hexCasting$mapIotaData(Dynamic<?> iota) {
+        String iotaType = iota.get(HEX_IOTA_TYPE).asString("");
+        Dynamic<?> iotaData = iota.get(HEX_DATA).orElseEmptyMap();
         Map<Dynamic<?>, Dynamic<?>> component = new HashMap<>();
-        component.put(dynamic.createString("type"), dynamic.createString(iotaType));
+        component.put(iota.createString("type"), iota.createString(iotaType));
         switch (iotaType) {
-            case "hexcasting:double":
-                component.put(dynamic.createString("value"), hexData);
-                break;
             case "hexcasting:entity":
-                IntStream uuid = hexData.get("uuid").asIntStream();
+                IntStream uuid = iotaData.get("uuid").asIntStream();
                 // Unfortunately, it seems like we cannot easily fix InlineAPI components, so we will have to live with "an unknown entity"
-                component.put(dynamic.createString("entityId"), dynamic.createIntList(uuid));
-                component.put(dynamic.createString("isPlayer"), dynamic.createBoolean(true));
+                component.put(iota.createString("entityId"), iota.createIntList(uuid));
+                component.put(iota.createString("isPlayer"), iota.createBoolean(true));
                 break;
-                // TODO: correctly fix each iota type. Can we somehow even do this for non-basemod iotas?
+            case "hexcasting:boolean":
+            case "hexcasting:double":
+                component.put(iota.createString("value"), iotaData);
+                break;
+            case "hexcasting:list":
+                List<Dynamic<?>> listData = iotaData.asList(MixinItemStackComponentizationFix::hexCasting$mapIotaData);
+                component.put(iota.createString("list"), iota.createList(listData.stream()));
+                break;
+            case "hexcasting:pattern":
+                component.put(iota.createString("value"), hexCasting$mapPattern(iotaData));
+                break;
+            case "hexcasting:vec3":
+                component.put(iota.createString("value"), hexCasting$mapVec3(iotaData));
+                break;
+            case "hexcasting:continuation":
+                List<Dynamic<?>> frames = iotaData.asList(MixinItemStackComponentizationFix::hexCasting$mapContinuationFrame);
+                component.put(iota.createString("value"), iota.createList(frames.stream()));
+                break;
+            case "hexcasting:null":
+            case "hexcasting:garbage":
+            default:
+                break;
         }
-        component.put(dynamic.createString("value"), hexData);
-        itemStackData.setComponent("hexcasting:iota", dynamic.createMap(component));
-        if (sealed) itemStackData.setComponent("hexcasting:sealed", dynamic.createMap(Map.of()));
+        return iota.createMap(component);
     }
 
     @Unique
     private static final String[] hexCasting$hexDir = {"NORTH_EAST", "EAST", "SOUTH_EAST", "SOUTH_WEST", "WEST", "NORTH_WEST"};
     @Unique
     private static final String[] hexCasting$hexAngle = {"w", "e", "d", "s", "a", "q"};
-
     @Unique
-    private static void hexCasting$fixScroll(ItemStackData itemStackData, Dynamic<?> dynamic) {
-        Dynamic<?> pattern = itemStackData.removeTag("pattern").orElseEmptyMap();
+    private static Dynamic<?> hexCasting$mapPattern(Dynamic<?> pattern) {
+        Map<Dynamic<?>, Dynamic<?>> patternComponent = new HashMap<>();
         byte startDir = pattern.get("start_dir").asByte((byte) 0);
         List<Byte> angles = pattern.get("angles").asList(dynamic0 -> dynamic0.asByte((byte) 0));
-        Map<Dynamic<?>, Dynamic<?>> patternComponent = new HashMap<>();
-        patternComponent.put(dynamic.createString(HexPattern.TAG_START_DIR), dynamic.createString(hexCasting$hexDir[startDir]));
-        patternComponent.put(dynamic.createString(HexPattern.TAG_ANGLES), dynamic.createString(String.join("", angles.stream().map(a -> hexCasting$hexAngle[a]).toList())));
-        itemStackData.setComponent("hexcasting:pattern", dynamic.createMap(patternComponent));
+        patternComponent.put(pattern.createString(HexPattern.TAG_START_DIR), pattern.createString(hexCasting$hexDir[startDir]));
+        patternComponent.put(pattern.createString(HexPattern.TAG_ANGLES), pattern.createString(String.join("", angles.stream().map(a -> hexCasting$hexAngle[a]).toList())));
+        return pattern.createMap(patternComponent);
+    }
 
+    @Unique
+    private static Dynamic<?> hexCasting$mapVec3(Dynamic<?> iotaData) {
+        double x = iotaData.get("x").asDouble(0);
+        double y = iotaData.get("y").asDouble(0);
+        double z = iotaData.get("z").asDouble(0);
+        return iotaData.createList(Stream.of(iotaData.createDouble(x), iotaData.createDouble(y), iotaData.createDouble(z)));
+    }
+
+    @Unique
+    private static Dynamic<?> hexCasting$mapContinuationFrame(Dynamic<?> dynamic) {
+        throw new NotImplementedException();
+    }
+
+    @Unique
+    private static void hexCasting$fixScroll(ItemStackData itemStackData) {
+        itemStackData.fixSubTag("pattern", true, MixinItemStackComponentizationFix::hexCasting$mapPattern);
+
+        itemStackData.moveTagToComponent("pattern", "hexcasting:pattern");
         itemStackData.moveTagToComponent("op_id", "hexcasting:op_id");
         itemStackData.moveTagToComponent("recalc_warning", "hexcasting:recalc_warning");
         itemStackData.moveTagToComponent("needs_purchase", "hexcasting:needs_purchase");

--- a/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
+++ b/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
@@ -1,0 +1,21 @@
+package at.petrak.hexcasting.mixin.datafixer;
+
+import com.mojang.serialization.Dynamic;
+import java.util.Map;
+import net.minecraft.util.datafix.fixes.ItemStackComponentizationFix;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ItemStackComponentizationFix.class)
+public class MixinItemStackComponentizationFix {
+    @Inject(method = "fixItemStack", at = @At("TAIL"))
+    private static void fixHexItemStack(ItemStackComponentizationFix.ItemStackData itemStackData, Dynamic<?> dynamic, CallbackInfo ci) {
+        if (itemStackData.is("hexcasting:focus")) {
+            Map<String, Dynamic<?>> data = itemStackData.removeTag("data").asMap((dynamicx) -> dynamicx.asString(""), (dynamicx) -> dynamicx);
+            Dynamic<?> component = dynamic.createMap(Map.of(dynamic.createString("type"), data.get("hexcasting:type"), dynamic.createString("value"), data.get("hexcasting:data")));
+            itemStackData.setComponent("hexcasting:iota", component);
+        }
+    }
+}

--- a/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
+++ b/Common/src/main/java/at/petrak/hexcasting/mixin/datafixer/MixinItemStackComponentizationFix.java
@@ -56,7 +56,7 @@ public class MixinItemStackComponentizationFix {
             itemStackData.moveTagToComponent("value", "hexcasting:abacus_value");
         }
         if (itemStackData.is("hexcasting:spellbook")) {
-            hexCasting$fixSpellbook(itemStackData, dynamic);
+            hexCasting$fixSpellbook(itemStackData);
         }
         if (item instanceof IotaHolderItem) {
             itemStackData.moveTagToComponent("VisualOverride", "hexcasting:visual_override");
@@ -65,7 +65,7 @@ public class MixinItemStackComponentizationFix {
             itemStackData.moveTagToComponent("variant", "hexcasting:variant");
         }
         if (item instanceof ItemPackagedHex) {
-            // TODO: wait for #1220, then hex holder component
+            hexCasting$fixPackagedHex(itemStackData, dynamic);
         }
         if (item instanceof ItemMediaHolder) {
             itemStackData.moveTagToComponent("hexcasting:media", "hexcasting:media");
@@ -191,7 +191,7 @@ public class MixinItemStackComponentizationFix {
     }
 
     @Unique
-    private static void hexCasting$fixSpellbook(ItemStackData itemStackData, Dynamic<?> dynamic) {
+    private static void hexCasting$fixSpellbook(ItemStackData itemStackData) {
         itemStackData.moveTagToComponent("page_idx", "hexcasting:page_idx");
 
         itemStackData.fixSubTag("page_names", true, d0 ->
@@ -203,5 +203,16 @@ public class MixinItemStackComponentizationFix {
         itemStackData.moveTagToComponent("pages", "hexcasting:pages");
 
         itemStackData.moveTagToComponent("sealed_pages", "hexcasting:sealed_pages");
+    }
+
+    @Unique
+    private static void hexCasting$fixPackagedHex(ItemStackData itemStackData, Dynamic<?> dynamic) {
+        Stream<Dynamic<?>> patterns = itemStackData.removeTag("patterns").asStream()
+            .map(MixinItemStackComponentizationFix::hexCasting$mapIotaData);
+        Dynamic<?> pigment = itemStackData.removeTag("pigment").orElseEmptyMap();
+        Dynamic<?> hexHolder = dynamic.createMap(Map.of(
+            dynamic.createString("hex"), dynamic.createList(patterns),
+            dynamic.createString("pigment"), pigment));
+        itemStackData.setComponent("hexcasting:hex_holder", hexHolder);
     }
 }

--- a/Common/src/main/resources/hexplat.accesswidener
+++ b/Common/src/main/resources/hexplat.accesswidener
@@ -9,3 +9,4 @@ accessible method net/minecraft/world/item/context/UseOnContext <init> (Lnet/min
 accessible method net/minecraft/world/damagesource/DamageSources source (Lnet/minecraft/resources/ResourceKey;)Lnet/minecraft/world/damagesource/DamageSource;
 accessible method net/minecraft/world/damagesource/DamageSources source (Lnet/minecraft/resources/ResourceKey;Lnet/minecraft/world/entity/Entity;)Lnet/minecraft/world/damagesource/DamageSource;
 accessible class net/minecraft/util/datafix/fixes/ItemStackComponentizationFix$ItemStackData
+accessible field net/minecraft/util/datafix/fixes/ItemStackComponentizationFix$ItemStackData item Ljava/lang/String;

--- a/Common/src/main/resources/hexplat.accesswidener
+++ b/Common/src/main/resources/hexplat.accesswidener
@@ -8,3 +8,4 @@ accessible method net/minecraft/world/item/crafting/Ingredient <init> (Ljava/uti
 accessible method net/minecraft/world/item/context/UseOnContext <init> (Lnet/minecraft/world/level/Level;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/InteractionHand;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/phys/BlockHitResult;)V
 accessible method net/minecraft/world/damagesource/DamageSources source (Lnet/minecraft/resources/ResourceKey;)Lnet/minecraft/world/damagesource/DamageSource;
 accessible method net/minecraft/world/damagesource/DamageSources source (Lnet/minecraft/resources/ResourceKey;Lnet/minecraft/world/entity/Entity;)Lnet/minecraft/world/damagesource/DamageSource;
+accessible class net/minecraft/util/datafix/fixes/ItemStackComponentizationFix$ItemStackData

--- a/Common/src/main/resources/hexplat.mixins.json
+++ b/Common/src/main/resources/hexplat.mixins.json
@@ -16,7 +16,8 @@
     "accessor.AccessorLivingEntity",
     "accessor.AccessorLootTable",
     "accessor.AccessorUseOnContext",
-    "accessor.AccessorVillager"
+    "accessor.AccessorVillager",
+    "datafixer.MixinItemStackComponentizationFix"
   ],
   "client": [
     "accessor.client.AccessorBlockEntityRenderDispatcher",

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/cc/HexCardinalComponents.java
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/cc/HexCardinalComponents.java
@@ -2,7 +2,6 @@ package at.petrak.hexcasting.fabric.cc;
 
 import at.petrak.hexcasting.api.addldata.*;
 import at.petrak.hexcasting.common.entities.EntityWallScroll;
-import at.petrak.hexcasting.common.lib.HexDataComponents;
 import at.petrak.hexcasting.fabric.cc.adimpl.*;
 import net.fabricmc.fabric.api.lookup.v1.item.ItemApiLookup;
 import net.minecraft.server.level.ServerPlayer;
@@ -16,14 +15,12 @@ import org.ladysnake.cca.api.v3.component.ComponentRegistry;
 import org.ladysnake.cca.api.v3.entity.EntityComponentFactoryRegistry;
 import org.ladysnake.cca.api.v3.entity.EntityComponentInitializer;
 import org.ladysnake.cca.api.v3.entity.RespawnCopyStrategy;
-import org.ladysnake.cca.api.v3.item.ItemComponentInitializer;
-import org.ladysnake.cca.api.v3.item.ItemComponentMigrationRegistry;
 
 import java.util.function.Function;
 
 import static at.petrak.hexcasting.api.HexAPI.modLoc;
 
-public class HexCardinalComponents implements EntityComponentInitializer, ItemComponentInitializer {
+public class HexCardinalComponents implements EntityComponentInitializer {
     // entities
     public static final ComponentKey<CCBrainswept> BRAINSWEPT = ComponentRegistry.getOrCreate(modLoc("brainswept"),
         CCBrainswept.class);
@@ -86,21 +83,6 @@ public class HexCardinalComponents implements EntityComponentInitializer, ItemCo
             ItemDelegatingEntityIotaHolder.ToItemFrame::new));
         registry.registerFor(EntityWallScroll.class, IOTA_HOLDER,
             wrapItemEntityDelegate(ItemDelegatingEntityIotaHolder.ToWallScroll::new));
-    }
-
-    @Override
-    public void registerItemComponentMigrations(ItemComponentMigrationRegistry registry) {
-        registry.registerMigration(modLoc("pigment"), HexDataComponents.PIGMENT.get());
-
-        registry.registerMigration(modLoc("iota_holder"), HexDataComponents.IOTA_HOLDER_IOTA.get());
-        // oh havoc, you think you're so funny
-        // the worst part is you're /right/
-
-        registry.registerMigration(modLoc("media_holder"), HexDataComponents.MEDIA.get());
-
-        registry.registerMigration(modLoc("hex_holder"), HexDataComponents.HEX_HOLDER_PATTERNS.get());
-
-        registry.registerMigration(modLoc("variant_item"), HexDataComponents.ITEM_VARIANT.get());
     }
 
     private <E extends Entity> ComponentFactory<E, CCEntityIotaHolder.Wrapper> wrapItemEntityDelegate(Function<E,


### PR DESCRIPTION
Closes #1214 

Due to the switch from NBT data to components, items carried over from 1.20 to 1.21 don't retain stored data at the moment.
This PR implements an automatic fix for that, mixing into the process that vanilla Minecraft uses to do the same to its items.

As @IridescentVoid pointed out, a sample like this would probably also be a good addition to a 1.21 addon template.