### PR TITLE
feat: add entity explosion resistance option

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/mod/HexConfig.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/mod/HexConfig.java
@@ -27,7 +27,7 @@ public class HexConfig {
 
         int artifactCooldown();
 
-        int entityExplosionResistance();
+        int explosionScaling();
 
         long DEFAULT_DUST_MEDIA_AMOUNT = MediaConstants.DUST_UNIT;
         long DEFAULT_SHARD_MEDIA_AMOUNT = MediaConstants.SHARD_UNIT;
@@ -38,7 +38,7 @@ public class HexConfig {
         int DEFAULT_TRINKET_COOLDOWN = 5;
         int DEFAULT_ARTIFACT_COOLDOWN = 3;
 
-        int DEFAULT_ENTITY_EXPLOSION_RESISTANCE = 0;
+        int DEFAULT_EXPLOSION_SCALING = 100;
     }
 
     public interface ClientConfigAccess {

--- a/Common/src/main/java/at/petrak/hexcasting/api/mod/HexConfig.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/mod/HexConfig.java
@@ -27,6 +27,8 @@ public class HexConfig {
 
         int artifactCooldown();
 
+        int entityExplosionResistance();
+
         long DEFAULT_DUST_MEDIA_AMOUNT = MediaConstants.DUST_UNIT;
         long DEFAULT_SHARD_MEDIA_AMOUNT = MediaConstants.SHARD_UNIT;
         long DEFAULT_CHARGED_MEDIA_AMOUNT = MediaConstants.CRYSTAL_UNIT;
@@ -36,6 +38,7 @@ public class HexConfig {
         int DEFAULT_TRINKET_COOLDOWN = 5;
         int DEFAULT_ARTIFACT_COOLDOWN = 3;
 
+        int DEFAULT_ENTITY_EXPLOSION_RESISTANCE = 0;
     }
 
     public interface ClientConfigAccess {

--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/spells/OpExplode.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/spells/OpExplode.kt
@@ -8,9 +8,13 @@ import at.petrak.hexcasting.api.casting.getPositiveDoubleUnderInclusive
 import at.petrak.hexcasting.api.casting.getVec3
 import at.petrak.hexcasting.api.casting.iota.Iota
 import at.petrak.hexcasting.api.misc.MediaConstants
+import at.petrak.hexcasting.api.mod.HexConfig
 import at.petrak.hexcasting.common.casting.actions.selectors.OpGetEntitiesBy
 import net.minecraft.core.BlockPos
 import net.minecraft.util.Mth
+import net.minecraft.world.effect.MobEffectInstance
+import net.minecraft.world.effect.MobEffects
+import net.minecraft.world.entity.LivingEntity
 import net.minecraft.world.level.Level
 import net.minecraft.world.phys.AABB
 import net.minecraft.world.phys.Vec3
@@ -52,6 +56,25 @@ class OpExplode(val fire: Boolean) : SpellAction {
             // TODO: you can use this to explode things *outside* of the worldborder?
             if (!env.canEditBlockAt(BlockPos.containing(pos)))
                 return
+
+            val resistanceLevel = HexConfig.common().entityExplosionResistance()
+
+            if (resistanceLevel > 0) {
+                val radius = strength * 4 / 3; // approximation
+                val aabb = AABB(pos.add(Vec3(-radius, -radius, -radius)), pos.add(Vec3(radius, radius, radius)))
+                val entitiesGot = env.world.getEntities(null, aabb)
+                    .filter { entity -> entity is LivingEntity && entity != env.castingEntity }
+                    .map { entity -> entity as LivingEntity }
+                entitiesGot.forEach { entity ->
+                    entity.addEffect(
+                        MobEffectInstance(
+                            MobEffects.DAMAGE_RESISTANCE,
+                            1, // 1 tick only, we want this to exclusively block the explosion
+                            resistanceLevel - 1
+                        )
+                    )
+                }
+            }
 
             env.world.explode(
                 env.castingEntity,

--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/spells/OpExplode.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/spells/OpExplode.kt
@@ -8,13 +8,10 @@ import at.petrak.hexcasting.api.casting.getPositiveDoubleUnderInclusive
 import at.petrak.hexcasting.api.casting.getVec3
 import at.petrak.hexcasting.api.casting.iota.Iota
 import at.petrak.hexcasting.api.misc.MediaConstants
-import at.petrak.hexcasting.api.mod.HexConfig
 import at.petrak.hexcasting.common.casting.actions.selectors.OpGetEntitiesBy
+import at.petrak.hexcasting.helper.ExplosionSourceTracker
 import net.minecraft.core.BlockPos
 import net.minecraft.util.Mth
-import net.minecraft.world.effect.MobEffectInstance
-import net.minecraft.world.effect.MobEffects
-import net.minecraft.world.entity.LivingEntity
 import net.minecraft.world.level.Level
 import net.minecraft.world.phys.AABB
 import net.minecraft.world.phys.Vec3
@@ -57,34 +54,20 @@ class OpExplode(val fire: Boolean) : SpellAction {
             if (!env.canEditBlockAt(BlockPos.containing(pos)))
                 return
 
-            val resistanceLevel = HexConfig.common().entityExplosionResistance()
-
-            if (resistanceLevel > 0) {
-                val radius = strength * 4 / 3; // approximation
-                val aabb = AABB(pos.add(Vec3(-radius, -radius, -radius)), pos.add(Vec3(radius, radius, radius)))
-                val entitiesGot = env.world.getEntities(null, aabb)
-                    .filter { entity -> entity is LivingEntity && entity != env.castingEntity }
-                    .map { entity -> entity as LivingEntity }
-                entitiesGot.forEach { entity ->
-                    entity.addEffect(
-                        MobEffectInstance(
-                            MobEffects.DAMAGE_RESISTANCE,
-                            1, // 1 tick only, we want this to exclusively block the explosion
-                            resistanceLevel - 1
-                        )
-                    )
-                }
+            ExplosionSourceTracker.setSpellSource(true)
+            try {
+                env.world.explode(
+                    env.castingEntity,
+                    pos.x,
+                    pos.y,
+                    pos.z,
+                    strength.toFloat(),
+                    this.fire,
+                    Level.ExplosionInteraction.TNT
+                )
+            } finally {
+                ExplosionSourceTracker.setSpellSource(false)
             }
-
-            env.world.explode(
-                env.castingEntity,
-                pos.x,
-                pos.y,
-                pos.z,
-                strength.toFloat(),
-                this.fire,
-                Level.ExplosionInteraction.TNT
-            )
         }
     }
 }

--- a/Common/src/main/java/at/petrak/hexcasting/helper/ExplosionSourceTracker.java
+++ b/Common/src/main/java/at/petrak/hexcasting/helper/ExplosionSourceTracker.java
@@ -1,0 +1,13 @@
+package at.petrak.hexcasting.helper;
+
+public final class ExplosionSourceTracker {
+    private static final ThreadLocal<Boolean> IS_SPELL_SOURCE = ThreadLocal.withInitial(() -> false);
+
+    public static boolean isSpellSource() {
+        return IS_SPELL_SOURCE.get();
+    }
+
+    public static void setSpellSource(boolean spellSource) {
+        IS_SPELL_SOURCE.set(spellSource);
+    }
+}

--- a/Common/src/main/java/at/petrak/hexcasting/mixin/MixinExplosion.java
+++ b/Common/src/main/java/at/petrak/hexcasting/mixin/MixinExplosion.java
@@ -1,0 +1,19 @@
+package at.petrak.hexcasting.mixin;
+
+import at.petrak.hexcasting.api.mod.HexConfig;
+import at.petrak.hexcasting.helper.ExplosionSourceTracker;
+import net.minecraft.world.level.Explosion;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
+
+@Mixin(Explosion.class)
+public abstract class MixinExplosion {
+    @ModifyArgs(method = "explode", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;hurt(Lnet/minecraft/world/damagesource/DamageSource;F)Z"))
+    private void scaleEntityExplosionDamage(Args args) {
+        if (ExplosionSourceTracker.isSpellSource()) {
+            args.set(1, (Float) args.get(1) * HexConfig.common().explosionScaling() / 100f);
+        }
+    }
+}

--- a/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
+++ b/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
@@ -337,6 +337,10 @@
           "": "Artifact Cooldown",
           "@Tooltip": "Cooldown of an artifact in ticks",
         },
+        explosionScaling: {
+          "": "Explosion Scaling",
+          "@Tooltip": "Scaling for entity damage caused by explosion spells in %",
+        },
       },
       
       client: {

--- a/Common/src/main/resources/hexplat.mixins.json
+++ b/Common/src/main/resources/hexplat.mixins.json
@@ -11,6 +11,7 @@
     "MixinVillager",
     "MixinWanderingTrader",
     "MixinWitch",
+    "MixinExplosion",
     "accessor.AccessorAbstractArrow",
     "accessor.AccessorEntity",
     "accessor.AccessorLivingEntity",

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexConfig.java
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexConfig.java
@@ -80,6 +80,8 @@ public class FabricHexConfig extends PartitioningSerializer.GlobalData {
         @ConfigEntry.Gui.Tooltip
         private int artifactCooldown = DEFAULT_ARTIFACT_COOLDOWN;
 
+        @ConfigEntry.Gui.Tooltip
+        private int entityExplosionResistance = DEFAULT_ENTITY_EXPLOSION_RESISTANCE;
 
         @Override
         public void validatePostLoad() throws ValidationException {
@@ -122,6 +124,11 @@ public class FabricHexConfig extends PartitioningSerializer.GlobalData {
         @Override
         public int artifactCooldown() {
             return artifactCooldown;
+        }
+
+        @Override
+        public int entityExplosionResistance() {
+            return entityExplosionResistance;
         }
     }
 

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexConfig.java
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexConfig.java
@@ -81,7 +81,7 @@ public class FabricHexConfig extends PartitioningSerializer.GlobalData {
         private int artifactCooldown = DEFAULT_ARTIFACT_COOLDOWN;
 
         @ConfigEntry.Gui.Tooltip
-        private int entityExplosionResistance = DEFAULT_ENTITY_EXPLOSION_RESISTANCE;
+        private int explosionScaling = DEFAULT_EXPLOSION_SCALING;
 
         @Override
         public void validatePostLoad() throws ValidationException {
@@ -127,9 +127,10 @@ public class FabricHexConfig extends PartitioningSerializer.GlobalData {
         }
 
         @Override
-        public int entityExplosionResistance() {
-            return entityExplosionResistance;
+        public int explosionScaling() {
+            return explosionScaling;
         }
+
     }
 
     @Config(name = "client")

--- a/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexConfig.java
+++ b/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexConfig.java
@@ -23,6 +23,8 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
     private static ForgeConfigSpec.IntValue trinketCooldown;
     private static ForgeConfigSpec.IntValue artifactCooldown;
 
+    private static ForgeConfigSpec.IntValue entityExplosionResistance;
+
     public ForgeHexConfig(ForgeConfigSpec.Builder builder) {
         builder.push("Media Amounts");
         dustMediaAmount = builder.comment("How much media a single Amethyst Dust item is worth")
@@ -42,6 +44,11 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
             .defineInRange("trinketCooldown", DEFAULT_TRINKET_COOLDOWN, 0, Integer.MAX_VALUE);
         artifactCooldown = builder.comment("Cooldown in ticks of a artifact")
             .defineInRange("artifactCooldown", DEFAULT_ARTIFACT_COOLDOWN, 0, Integer.MAX_VALUE);
+        builder.pop();
+
+        builder.push("Misc");
+        entityExplosionResistance = builder.comment("How much entities should resist explosion damage, where the reduction is Value times 20%")
+                .defineInRange("entityExplosionResistance", DEFAULT_ENTITY_EXPLOSION_RESISTANCE, 0, 5);
         builder.pop();
     }
 
@@ -78,6 +85,11 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
     @Override
     public int artifactCooldown() {
         return artifactCooldown.get();
+    }
+
+    @Override
+    public int entityExplosionResistance() {
+        return entityExplosionResistance.get();
     }
 
     public static class Client implements HexConfig.ClientConfigAccess {

--- a/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexConfig.java
+++ b/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexConfig.java
@@ -23,7 +23,7 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
     private static ForgeConfigSpec.IntValue trinketCooldown;
     private static ForgeConfigSpec.IntValue artifactCooldown;
 
-    private static ForgeConfigSpec.IntValue entityExplosionResistance;
+    private static ForgeConfigSpec.IntValue explosionScaling;
 
     public ForgeHexConfig(ForgeConfigSpec.Builder builder) {
         builder.push("Media Amounts");
@@ -47,8 +47,8 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
         builder.pop();
 
         builder.push("Misc");
-        entityExplosionResistance = builder.comment("How much entities should resist explosion damage, where the reduction is Value times 20%")
-                .defineInRange("entityExplosionResistance", DEFAULT_ENTITY_EXPLOSION_RESISTANCE, 0, 5);
+        explosionScaling = builder.comment("Scaling for entity damage caused by explosion spells in %")
+                .defineInRange("explosionScaling", DEFAULT_EXPLOSION_SCALING, 0, Integer.MAX_VALUE);
         builder.pop();
     }
 
@@ -88,8 +88,8 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
     }
 
     @Override
-    public int entityExplosionResistance() {
-        return entityExplosionResistance.get();
+    public int explosionScaling() {
+        return explosionScaling.get();
     }
 
     public static class Client implements HexConfig.ClientConfigAccess {


### PR DESCRIPTION
Implements #1253

Since the mod does just spawn regular minecraft explosions I figured the best way to reduce their damage is giving mobs and players resistance. On explosion spawn, it checks the approximate explosion radius for any living entities and gives them resistance at the configured level for 1 tick.

To prevent possible abuse to parry other incoming damage the caster is excluded from this resistance. If somehow other players want to abuse the 1 tick of resistance they configured to get then more power to them. They get invulnerability from the damage anyway.

If the config option isn't set it shouldn't change the behavior of the mod at all compared to how it has been.