### PR TITLE
Remove last set of deprecated methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Internal
 
-- Removed APIs deprecated in `0.11.4` ([#1126](https://github.com/FallingColors/HexMod/pull/1126), [#1127](https://github.com/FallingColors/HexMod/pull/1127) [#1129](https://github.com/FallingColors/HexMod/pull/1129), [#1137](https://github.com/FallingColors/HexMod/pull/1137), [#1142](https://github.com/FallingColors/HexMod/pull/1142)) @s5bug
+- Removed APIs deprecated in `0.11.4` ([#1126](https://github.com/FallingColors/HexMod/pull/1126), [#1127](https://github.com/FallingColors/HexMod/pull/1127) [#1129](https://github.com/FallingColors/HexMod/pull/1129), [#1137](https://github.com/FallingColors/HexMod/pull/1137), [#1142](https://github.com/FallingColors/HexMod/pull/1142), [#1256](http://github.com/FallingColors/HexMod/pull/1256)) @s5bug @Robotgiggle
 - ListIota now uses the asymptotically-efficient TreeList internally ([#1032](https://github.com/FallingColors/HexMod/pull/1032)) @s5bug
 - SpellList has been removed ([#1032](https://github.com/FallingColors/HexMod/pull/1032)) @s5bug
 - Casting Image and Casting Frames now store iotas in a TreeList ([#1033](https://github.com/FallingColors/HexMod/pull/1033)) @s5bug

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/CastingEnvironment.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/CastingEnvironment.java
@@ -57,18 +57,6 @@ public abstract class CastingEnvironment {
         createEventListeners.add(listener);
     }
 
-    /**
-     * Add a listener that will be called whenever a new CastingEnvironment is created (legacy).
-     *
-     * @deprecated replaced by {@link #addCreateEventListener(BiConsumer)}
-     */
-    @Deprecated(since = "0.11.0-pre-660")
-    public static void addCreateEventListener(Consumer<CastingEnvironment> listener) {
-        createEventListeners.add((env, data) -> {
-            listener.accept(env);
-        });
-    }
-
     private boolean createEventTriggered = false;
 
     public final void triggerCreateEvent(CompoundTag userData) {
@@ -105,24 +93,10 @@ public abstract class CastingEnvironment {
         return HexConfig.server().maxOpCount();
     }
 
-    /**
-     * Get the caster. Might be null!
-     * <p>
-     * Implementations should NOT rely on this in general, use the methods on this class instead.
-     * This is mostly for spells (flight, etc)
-     *
-     * @deprecated as of build 0.11.1-7-pre-619 you are recommended to use {@link #getCastingEntity}
-     */
-    @Deprecated(since = "0.11.1-7-pre-619")
-    @Nullable
-    public ServerPlayer getCaster() {
-        return getCastingEntity() instanceof ServerPlayer sp ? sp : null;
-    }
-
     ;
 
     /**
-     * Gets the caster. Can be null if {@link #getCaster()} is also null
+     * Gets the caster. Can be null if there is no casting entity (such as with an unbound cleric impetus)
      *
      * @return the entity casting
      */

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/CircleCastEnv.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/CircleCastEnv.java
@@ -43,11 +43,6 @@ public class CircleCastEnv extends CastingEnvironment {
         return this.execState.getCaster(this.world);
     }
 
-    @Override
-    public @Nullable ServerPlayer getCaster() {
-        return this.execState.getCaster(this.world);
-    }
-
     public @Nullable BlockEntityAbstractImpetus getImpetus() {
         var entity = this.world.getBlockEntity(execState.impetusPos);
 
@@ -170,24 +165,24 @@ public class CircleCastEnv extends CastingEnvironment {
     @Override
     // TODO: Could do something like get items in inventories adjacent to the circle?
     public List<ItemStack> getUsableStacks(StackDiscoveryMode mode) {
-        if (this.getCaster() != null)
-            return getUsableStacksForPlayer(mode, null, this.getCaster());
+        if (this.getCastingEntity() instanceof ServerPlayer caster)
+            return getUsableStacksForPlayer(mode, null, caster);
         return new ArrayList<>();
     }
 
     @Override
     // TODO: Adjacent inv!
     public List<HeldItemInfo> getPrimaryStacks() {
-        if (this.getCaster() != null)
-            return getPrimaryStacksForPlayer(InteractionHand.OFF_HAND, this.getCaster());
+        if (this.getCastingEntity() instanceof ServerPlayer caster)
+            return getPrimaryStacksForPlayer(InteractionHand.OFF_HAND, caster);
         return List.of();
     }
 
     @Override
     // TODO: Adjacent inv!
     public boolean replaceItem(Predicate<ItemStack> stackOk, ItemStack replaceWith, @Nullable InteractionHand hand) {
-        if (this.getCaster() != null)
-            return replaceItemForPlayer(stackOk, replaceWith, hand, this.getCaster());
+        if (this.getCastingEntity() instanceof ServerPlayer caster)
+            return replaceItemForPlayer(stackOk, replaceWith, hand, caster);
         return false;
     }
 

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/PlayerBasedCastEnv.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/PlayerBasedCastEnv.java
@@ -63,11 +63,6 @@ public abstract class PlayerBasedCastEnv extends CastingEnvironment {
     }
 
     @Override
-    public ServerPlayer getCaster() {
-        return this.caster;
-    }
-
-    @Override
     protected double getCostModifier(PatternShapeMatch match) {
         ResourceLocation loc = actionKey(match);
         if (loc != null && isOfTag(IXplatAbstractions.INSTANCE.getActionRegistry(), loc, HexTags.Actions.CANNOT_MODIFY_COST)) {

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapDisallowedSpell.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapDisallowedSpell.kt
@@ -11,9 +11,6 @@ import net.minecraft.resources.ResourceLocation
 import net.minecraft.world.item.DyeColor
 
 class MishapDisallowedSpell(val type: String, val actionKey: ResourceLocation?) : Mishap() {
-    @Deprecated("Provide the type (disallowed or disallowed_circle) and the action key that caused the mishap")
-    constructor(type: String = "disallowed") : this(type, null) {}
-
     override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.BLACK)
 

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapInvalidPattern.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapInvalidPattern.kt
@@ -12,9 +12,6 @@ import net.minecraft.network.chat.Component
 import net.minecraft.world.item.DyeColor
 
 class MishapInvalidPattern(val pattern: HexPattern?) : Mishap() {
-    @Deprecated("Provide the pattern that caused the mishap as an argument")
-    constructor() : this(null) {}
-
     override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.YELLOW)
 


### PR DESCRIPTION
Resolves #1093.

Specifically, this PR removes:
- `CastingEnvironment.addCreateEventListener()`
- `CastingEnvironment.getCaster()` and its overrides in `CircleCastEnv` and `PlayerBasedCastEnv`
- the single-argument `MishapDisallowedSpell` constructor
- the zero-argument `MishapInvalidPattern` constructor

It also makes some slight changes to `CircleCastEnv` to account for the removal of `getCaster()`, and updates the doc comment for `CastingEnvironment.getCastingEntity()` to no longer refer to `getCaster()`.