### PR TITLE
fix: Stop adding knockback on overcasting damage

### DIFF
--- a/Common/build.gradle
+++ b/Common/build.gradle
@@ -13,11 +13,11 @@ repositories {
     // paucal, patchi, inline, JEI
     maven { url 'https://maven.blamejared.com' }
 
-    /*maven {
-        // location of the maven that hosts JEI files, temporarily disabled due to HTTP 523 errors
+    maven {
+        // location of the maven that hosts JEI files
         name = "Progwml6 maven"
         url = "https://dvs1.progwml6.com/files/maven/"
-    }*/
+    }
     maven {
         // fallback maven for JEI
         name = "ModMaven"

--- a/Common/build.gradle
+++ b/Common/build.gradle
@@ -13,11 +13,11 @@ repositories {
     // paucal, patchi, inline, JEI
     maven { url 'https://maven.blamejared.com' }
 
-    maven {
-        // location of the maven that hosts JEI files
+    /*maven {
+        // location of the maven that hosts JEI files, temporarily disabled due to HTTP 523 errors
         name = "Progwml6 maven"
         url = "https://dvs1.progwml6.com/files/maven/"
-    }
+    }*/
     maven {
         // fallback maven for JEI
         name = "ModMaven"

--- a/Common/src/generated/resources/data/minecraft/tags/damage_type/no_knockback.json
+++ b/Common/src/generated/resources/data/minecraft/tags/damage_type/no_knockback.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "hexcasting:overcast"
+  ]
+}

--- a/Common/src/main/java/at/petrak/hexcasting/datagen/tag/HexDamageTypeTagProvider.java
+++ b/Common/src/main/java/at/petrak/hexcasting/datagen/tag/HexDamageTypeTagProvider.java
@@ -22,7 +22,8 @@ public class HexDamageTypeTagProvider extends DamageTypeTagsProvider {
         add(HexDamageTypes.OVERCAST,
             DamageTypeTags.BYPASSES_ARMOR,
             DamageTypeTags.BYPASSES_EFFECTS,
-            DamageTypeTags.BYPASSES_SHIELD
+            DamageTypeTags.BYPASSES_SHIELD,
+            DamageTypeTags.NO_KNOCKBACK
         );
     }
 

--- a/Neoforge/src/generated/resources/data/minecraft/tags/damage_type/no_knockback.json
+++ b/Neoforge/src/generated/resources/data/minecraft/tags/damage_type/no_knockback.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "hexcasting:overcast"
+  ]
+}


### PR DESCRIPTION
Fixes #1192 

A new damage type tag was introduced between 1.20.1 and 1.21.1 that determines whether a certain damage type deals knockback along with it. This PR adds that `#no_knockback` tag to the overcasting damge type.

As for the suggestion of a new sound for this damage type, I personally don't have a sound available or in mind, but I am open for input.