### PR TITLE
fix: don't fail on lookup of non per-world pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed Pace Purification returning nonzero velocity on nonmoving items ([#1119](https://github.com/FallingColors/HexMod/pull/1119)) @IridescentVoid
 - Fixed Accessor's Purification returning false for scrolls in item frames ([#1115](https://github.com/FallingColors/HexMod/pull/1115)) @IridescentVoid
 - Fixed Break Block being unable to break cobwebs on Fabric ([#1218](https://github.com/FallingColors/HexMod/pull/1218)) @Robotgiggle
+- Fixed the command to list all per-world patterns not working ([#1277](https://github.com/FallingColors/HexMod/pull/1277)) @Olfi01
 
 ### Internal
 

--- a/Common/src/main/java/at/petrak/hexcasting/common/command/ListPerWorldPatternsCommand.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/command/ListPerWorldPatternsCommand.java
@@ -75,6 +75,8 @@ public class ListPerWorldPatternsCommand {
         for (var key : listing) {
             var pat = PatternRegistryManifest.getCanonicalStrokesPerWorld(key, ow);
 
+            if (pat == null) continue;  // pattern doesn't appear to be a per-world pattern
+
             source.sendSuccess(() -> Component.literal(key.location().toString())
                 .append(": ")
                 .append(new PatternIota(pat).display()), false);


### PR DESCRIPTION
Closes #849 

The command is currently trying to look up canonical strokes for _every_ pattern instead of just the per-world patterns. This PR makes it skip patterns that do not have a per-world stroke order.