### PR TITLE
Bump mod version to 0.11.4, fix Fabric gaslighting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,7 +26,7 @@ body:
   - type: input
     attributes:
       label: Hex Casting version
-      placeholder: eg. 0.11.3
+      placeholder: eg. 0.11.4
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [UNRELEASED]
+## `0.11.4` - 2026-08-26
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed Break Block being unable to break cobwebs on Fabric ([#1218](https://github.com/FallingColors/HexMod/pull/1218)) @Robotgiggle
 - Fixed the zero vector not being listed as falsy on the Augur's Purification page ([#1273](https://github.com/FallingColors/HexMod/pull/1273)) @DetermiedMech1
 - Fixed the command to list all per-world patterns not working ([#1277](https://github.com/FallingColors/HexMod/pull/1277)) @Olfi01
+- Fixed a mixin issue that made gaslighting not work properly on Fabric ([#1281](https://github.com/FallingColors/HexMod/pull/1281)) @Robotgiggle
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Changed the `media_consumption` attribute to only apply to player-based casting ([#987](https://github.com/FallingColors/HexMod/pull/987)) @Robotgiggle
 - Changed Wayfarer's Flight and Anchorite's Flight to both cost 2 dust per unit, and enforced a minimum cost for Anchorite's Flight ([#1040](https://github.com/FallingColors/HexMod/pull/1040)) @Robotgiggle
-- Changed the pattern limit to also include execution of non-pattern iotas like jumps ([#1035](https://github.com/FallingColors/HexMod/pull/1035)) @pythonmcpi
 - Changed the Hasty Retrospection mishap to Absent Introspection as it's now used for anything that only works while parenthesized ([#1047](https://github.com/FallingColors/HexMod/pull/1047)) @Robotgiggle
 - Updated and reorganized various entries in the guidebook to improve clarity ([#1199](https://github.com/FallingColors/HexMod/pull/1199)) @Robotgiggle
   - Added a new entry defining what a Hex actually is and how it can be represented on the stack
@@ -50,6 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - Removed "Influences" and moved relevant info into "Hex Casting 101"
 - Updated the Flay Mind recipe display in EMI and JEI to cycle through all valid entities if the input is an entity tag ([#1023](https://github.com/FallingColors/HexMod/pull/1023)) @YukkuriC
 - All custom recipe displays now work with both EMI and JEI on all platforms, rather than only EMI on Fabric and only JEI on Forge ([#1206](https://github.com/FallingColors/HexMod/pull/1206)) @Robotgiggle
+- The pattern limit is now checked even when executing non-pattern iotas like jumps ([#1035](https://github.com/FallingColors/HexMod/pull/1035)) @pythonmcpi
 - Re-implemented the ability to extract stored media from items in trinket/curio slots ([#996](https://github.com/FallingColors/HexMod/pull/996)) @YukkuriC
 - Patterns involving entity look direction now compensate for the vanilla bug that causes projectiles and phantoms to report the wrong direction ([#1025](https://github.com/FallingColors/HexMod/pull/1025)) @Robotgiggle
 - Edified Panels are now crafted with 9 planks rather than 8 to avoid conflicting with the vanilla chest recipe ([#1080](https://github.com/FallingColors/HexMod/pull/1080)) @Robotgiggle

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/mixin/client/FabricLevelRendererMixin.java
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/mixin/client/FabricLevelRendererMixin.java
@@ -27,7 +27,7 @@ public class FabricLevelRendererMixin {
         locals = LocalCapture.CAPTURE_FAILSOFT)
     private void snagFrustumFromLevelRenderer(PoseStack poseStack, float f, long arg2, boolean bl, Camera camera,
           GameRenderer gameRenderer, LightTexture lightTexture, Matrix4f matrix4f, CallbackInfo ci,
-          ProfilerFiller profilerFiller, boolean bl2, Vec3 vec3, double d, double e, double g, Matrix4f matrix4f2,
+          ProfilerFiller profilerFiller, Vec3 vec3, double d, double e, double g, Matrix4f matrix4f2,
           boolean bl3, Frustum frustum) {
         FabricClientXplatImpl.LEVEL_RENDERER_FRUSTUM = frustum;
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ jetbrainsAnnotationsVersion=23.0.0
 
 minecraftVersion=1.20.1
 kotlinVersion=2.2.21
-modVersion=0.11.3
+modVersion=0.11.4
 
 # this is the version published to modrinth/cf i swear
 paucalVersion=0.6.0-pre-118


### PR DESCRIPTION
- Fixes a mixin used to capture the camera frustum on Fabric
- Adjusts the changelog entry for #1035 to be more accurate
- Bumps mod version to 0.11.4 in appropriate places